### PR TITLE
Sanity check for excommunication.

### DIFF
--- a/CK2ToEU4/Source/EU4World/Country/Country.h
+++ b/CK2ToEU4/Source/EU4World/Country/Country.h
@@ -63,6 +63,7 @@ class Country
 	[[nodiscard]] const auto& getTag() const { return tag; }
 	[[nodiscard]] const auto& getAdvisers() const { return details.advisers; }
 	[[nodiscard]] auto getConversionDate() const { return conversionDate; }
+	[[nodiscard]] auto isExcommunicated() const { return details.excommunicated; }
 
 	void registerProvince(std::pair<int, std::shared_ptr<Province>> theProvince) { provinces.insert(std::move(theProvince)); }
 	void setPrimaryCulture(const std::string& culture);
@@ -78,6 +79,7 @@ class Country
 	void setMonarch(const Character& monarch) { details.monarch = monarch; }
 	void clearHistoryLessons() { details.historyLessons.clear(); }
 	void setConversionDate(date theDate) { conversionDate = theDate; }
+	void clearExcommunicated() { details.excommunicated = false; }
 
 	friend std::ostream& operator<<(std::ostream& output, const Country& versionParser);
 

--- a/CK2ToEU4/Source/EU4World/EU4World.cpp
+++ b/CK2ToEU4/Source/EU4World/EU4World.cpp
@@ -544,6 +544,12 @@ void EU4::World::verifyReligionsAndCultures()
 	// We are checking every country if it lacks primary religion and culture. This is an issue for hordeland mainly.
 	// For those lacking setups, we'll do a provincial census and inherit those values.
 	for (const auto& country: countries) {
+		// It's possible to get non-christian countries excommunicated through broken setups. Let's clear those immediately.
+		if (country.second->isExcommunicated()) {
+			const auto& religion = country.second->getReligion();
+			if (religion != "catholic" || religion != "fraticelli") country.second->clearExcommunicated();
+		}
+		// And then proceed on checking the missing boxes.
 		if (!country.second->getReligion().empty() && !country.second->getPrimaryCulture().empty() && !country.second->getTechGroup().empty() &&
 			 !country.second->getGFX().empty())
 			continue;


### PR DESCRIPTION
- Having a non-catholic/fraticelli country excommunicated (through broken setups/missing mods) will crash the game. Better safe than sorry.