### PR TITLE
Electorate minor revamp

### DIFF
--- a/CK2ToEU4/Source/CK2World/Titles/Title.cpp
+++ b/CK2ToEU4/Source/CK2World/Titles/Title.cpp
@@ -1,7 +1,6 @@
 #include "Title.h"
 #include "../Characters/Character.h"
 #include "../Provinces/Province.h"
-#include "Liege.h"
 #include "Log.h"
 #include "ParserHelpers.h"
 
@@ -46,6 +45,11 @@ void CK2::Title::registerKeys()
 	registerKeyword("succession", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString successionStr(theStream);
 		successionLaw = successionStr.getString();
+	});
+	registerKeyword("succession_electors", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::intList theList(theStream);
+		const auto& electorIDs = theList.getInts();
+		electors.insert(electorIDs.begin(), electorIDs.end());
 	});
 	registerKeyword("base_title", [this](const std::string& unused, std::istream& theStream) {
 		// This can either be a single string or a Liege object.

--- a/CK2ToEU4/Source/CK2World/Titles/Title.h
+++ b/CK2ToEU4/Source/CK2World/Titles/Title.h
@@ -37,9 +37,11 @@ class Title: commonItems::parser
 	[[nodiscard]] const auto& getSuccessionLaw() const { return successionLaw; }
 	[[nodiscard]] const auto& getEU4Tag() const { return tagCountry; }
 	[[nodiscard]] const auto& getPreviousHolders() const { return previousHolders; }
+	[[nodiscard]] const auto& getElectors() const { return electors; }
 
 	[[nodiscard]] auto isInHRE() const { return inHRE; }
 	[[nodiscard]] auto isHREEmperor() const { return HREEmperor; }
+	[[nodiscard]] auto isElector() const { return electorate; }
 	[[nodiscard]] auto isMajorRevolt() const { return majorRevolt; }
 
 	[[nodiscard]] std::map<int, std::shared_ptr<Province>> coalesceProvinces() const;
@@ -56,6 +58,7 @@ class Title: commonItems::parser
 	void setDJLiegeBaseTitle(std::shared_ptr<Title> theBaseTitle) const { deJureLiege.second->setBaseTitle(std::move(theBaseTitle)); }
 	void setInHRE() { inHRE = true; }
 	void setHREEmperor() { HREEmperor = true; }
+	void setElectorate() { electorate = true; }
 	void setPreviousHolders(const std::map<int, std::shared_ptr<Character>>& thePreviousHolders) { previousHolders = thePreviousHolders; }
 	void overrideLiege() { liege = deJureLiege; }
 	void overrideLiege(const std::pair<std::string, std::shared_ptr<Liege>>& theLiege) { liege = theLiege; }
@@ -85,6 +88,7 @@ class Title: commonItems::parser
 	bool inHRE = false;
 	bool HREEmperor = false;
 	bool majorRevolt = false;
+	bool electorate = false;
 	std::string name;			 // nominal name, k_something
 	std::string displayName; // visual name, "Cumania"
 	std::string genderLaw;	 // for succession
@@ -92,6 +96,7 @@ class Title: commonItems::parser
 	commonItems::Color color;
 
 	std::set<std::string> laws;
+	std::set<int> electors;
 	std::map<int, std::shared_ptr<Province>> provinces;
 	std::map<int, std::shared_ptr<Province>> deJureProvinces;
 	std::map<std::string, std::shared_ptr<Title>> vassals;

--- a/CK2ToEU4/Source/CK2World/World.cpp
+++ b/CK2ToEU4/Source/CK2World/World.cpp
@@ -230,7 +230,7 @@ void CK2::World::linkElectors()
 	// Make a registry of indep titles and their holders.
 	std::map<int, std::map<std::string, std::shared_ptr<Title>>> holderTitles; // holder/titles
 	std::pair<int, std::shared_ptr<Character>> hreHolder;
-	
+
 	for (const auto& title: independentTitles)
 	{
 		if (title.second->getHolder().first)
@@ -260,44 +260,45 @@ void CK2::World::linkElectors()
 		{
 			continue; // We're skipping the emperor for 8-slot setups.
 		}
+
 		const auto& charItr = allCharacters.find(elector);
 		if (charItr == allCharacters.end())
 		{
 			continue; // Non-existent fellow?
 		}
+
 		// How many indep titles does he hold? If any?
 		const auto& regItr = holderTitles.find(elector);
 		if (regItr == holderTitles.end())
 		{
 			continue; // This fellow was cheated out of electorate titles.
 		}
+
 		if (regItr->second.size() > 1)
 		{
-			// Which titles is his primary?
+			// Which title is his primary?
 			const auto& primaryTitle = charItr->second->getPrimaryTitle();
 			if (primaryTitle.first.empty())
 			{
 				// We have a person without a primary title, possibly an ex-king, holding multiple actual titles.
 				// To make matters worse, he may not even be of a religion allowing PUs.
 				// Well, grab the first one with some land.
-				auto foundPrimary = false;
 				for (const auto& title: regItr->second)
 				{
 					if (!title.second->getProvinces().empty())
 					{
 						title.second->setElectorate();
 						counter++;
-						foundPrimary = true;
 						break;
 					}
 				}
-				if (!foundPrimary)
-				{
-					continue; // no helping this fellow.
-				}
+				// otherwise no helping this fellow.
 			}
-			primaryTitle.second->getTitle().second->setElectorate();
-			counter++;
+			else
+			{
+				primaryTitle.second->getTitle().second->setElectorate();
+				counter++;
+			}
 		}
 		else
 		{
@@ -876,7 +877,7 @@ void CK2::World::shatterEmpires(const Configuration& theConfiguration) const
 			shatterKingdoms = true;
 	}
 	const auto& allTitles = titles.getTitles();
-	
+
 	for (const auto& empire: allTitles)
 	{
 		if (theConfiguration.getShatterEmpires() == Configuration::SHATTER_EMPIRES::CUSTOM && !shatterEmpiresMapper.isEmpireShatterable(empire.first))

--- a/CK2ToEU4/Source/CK2World/World.h
+++ b/CK2ToEU4/Source/CK2World/World.h
@@ -60,6 +60,7 @@ class World: commonItems::parser
 	void linkCelestialEmperor() const;
 	void verifyReligionsAndCultures(const Configuration& theConfiguration);
 	void loadDynastiesFromMods(const Configuration& theConfiguration);
+	void linkElectors();
 
 	bool invasion = false;
 	date endDate = date("1444.11.11");

--- a/CK2ToEU4/Source/EU4World/EU4World.cpp
+++ b/CK2ToEU4/Source/EU4World/EU4World.cpp
@@ -693,7 +693,7 @@ void EU4::World::setElectors()
 				electors.emplace_back(country.second);
 				electorBishops++;
 				continue;
-			}			
+			}
 			// Let's shove all hre members into appropriate categories.
 			if (country.second->getGovernment() == "theocracy")
 			{

--- a/CK2ToEU4/Source/EU4World/EU4World.cpp
+++ b/CK2ToEU4/Source/EU4World/EU4World.cpp
@@ -51,7 +51,8 @@ EU4::World::World(const CK2::World& sourceWorld, const Configuration& theConfigu
 	importCK2Provinces(sourceWorld);
 
 	// With Ck2 provinces linked to those eu4 provinces they affect, we can adjust eu4 province dev values.
-	if (theConfiguration.getDevelopment() == Configuration::DEVELOPMENT::IMPORT) alterProvinceDevelopment();
+	if (theConfiguration.getDevelopment() == Configuration::DEVELOPMENT::IMPORT)
+		alterProvinceDevelopment();
 
 	// We then link them to their respective countries. Those countries that end up with 0 provinces are defacto dead.
 	linkProvincesToCountries();
@@ -355,7 +356,7 @@ void EU4::World::fixTengri()
 {
 	// We need to convert all unmapped EU4 Tengri provinces to Old Tengri (Unreformed)
 	Log(LogLevel::Info) << "<> Checking for Reformed Tengri";
-	for (const auto& province : provinces)
+	for (const auto& province: provinces)
 	{
 		if (!province.second->getSourceProvince())
 		{
@@ -365,7 +366,7 @@ void EU4::World::fixTengri()
 			}
 		}
 	}
-	for (const auto& country : countries)
+	for (const auto& country: countries)
 	{
 		if (country.second->getTitle().first.empty())
 		{
@@ -674,6 +675,9 @@ void EU4::World::setElectors()
 	std::vector<std::pair<int, std::shared_ptr<Country>>> duchies;	  // dev-tag
 	std::vector<std::pair<int, std::shared_ptr<Country>>> republics; // dev-tag
 	std::vector<std::shared_ptr<Country>> electors;
+	int electorBishops = 0;
+	int electorRepublics = 0;
+	int electorDuchies = 0;
 
 	// We need to be careful about papacy and orthodox holders
 	for (const auto& country: countries)
@@ -686,21 +690,49 @@ void EU4::World::setElectors()
 			if (country.first == "PAP" || holder.second->getPrimaryTitle().first == "k_orthodox")
 			{
 				// override to always be elector
-				bishops.emplace_back(std::pair(99999, country.second));
+				electors.emplace_back(country.second);
+				electorBishops++;
 				continue;
-			}
+			}			
 			// Let's shove all hre members into appropriate categories.
 			if (country.second->getGovernment() == "theocracy")
 			{
-				bishops.emplace_back(std::pair(lround(holder.second->getPiety()), country.second));
+				if (country.second->getTitle().second->isElector())
+				{
+					electorBishops++;
+					electors.emplace_back(country.second);
+				}
+				else
+				{
+					bishops.emplace_back(std::pair(lround(holder.second->getPiety()), country.second));
+				}
 			}
 			else if (country.second->getGovernment() == "monarchy")
 			{
-				duchies.emplace_back(std::pair(country.second->getDevelopment(), country.second));
+				if (country.second->getTitle().second->isElector())
+				{
+					electorDuchies++;
+					electors.emplace_back(country.second);
+				}
+				else
+				{
+					duchies.emplace_back(std::pair(country.second->getDevelopment(), country.second));
+				}
 			}
 			else if (country.second->getGovernment() == "republic")
 			{
-				republics.emplace_back(std::pair(country.second->getDevelopment(), country.second));
+				// No free cities, thank you!
+				if (country.second->getGovernmentReforms().count("free_city"))
+					continue;
+				if (country.second->getTitle().second->isElector())
+				{
+					electorRepublics++;
+					electors.emplace_back(country.second);
+				}
+				else
+				{
+					republics.emplace_back(std::pair(country.second->getDevelopment(), country.second));
+				}
 			} // skipping tribal and similar.
 		}
 	}
@@ -711,15 +743,17 @@ void EU4::World::setElectors()
 
 	for (const auto& bishop: bishops)
 	{
-		if (electors.size() >= 3)
+		if (electors.size() >= 7 || electorBishops >= 3)
 			break;
 		electors.emplace_back(bishop.second);
+		electorBishops++;
 	}
 	for (const auto& republic: republics)
 	{
-		if (electors.size() >= 3)
+		if (electors.size() >= 7 || electorBishops + electorRepublics >= 3)
 			break;
 		electors.emplace_back(republic.second);
+		electorRepublics++;
 	}
 	for (const auto& duchy: duchies)
 	{
@@ -729,7 +763,10 @@ void EU4::World::setElectors()
 	}
 
 	for (const auto& elector: electors)
+	{
 		elector->setElector();
+		Log(LogLevel::Info) << "\t- Electorate set: " << elector->getTag() << " (from " << elector->getTitle().first << ")";
+	}
 	LOG(LogLevel::Info) << "<> There are " << electors.size() << " electors recognized.";
 }
 
@@ -741,7 +778,7 @@ void EU4::World::setFreeCities()
 	for (const auto& country: countries)
 	{
 		if (country.second->isinHRE() && country.second->getGovernment() == "republic" && country.second->getProvinces().size() == 1 &&
-			 country.second->getTitle().second->getGeneratedLiege().first.empty() && freeCityNum < 8)
+			 country.second->getTitle().second->getGeneratedLiege().first.empty() && !country.second->getTitle().second->isElector() && freeCityNum < 8)
 		{
 			country.second->overrideReforms("free_city");
 			++freeCityNum;
@@ -754,7 +791,7 @@ void EU4::World::setFreeCities()
 		{
 			if (country.second->isinHRE() && country.second->getGovernment() != "republic" && !country.second->isHREEmperor() &&
 				 country.second->getGovernmentReforms().empty() && country.second->getProvinces().size() == 1 &&
-				 country.second->getTitle().second->getGeneratedLiege().first.empty() && freeCityNum < 8)
+				 country.second->getTitle().second->getGeneratedLiege().first.empty() && !country.second->getTitle().second->isElector() && freeCityNum < 8)
 			{
 				if (country.first == "HAB")
 					continue; // For Iohannes who is sensitive about Austria.
@@ -1198,7 +1235,7 @@ std::optional<std::pair<int, std::shared_ptr<CK2::Province>>> EU4::World::determ
 	{
 		return wonderProvince;
 	}
-	
+
 	std::pair<int, std::shared_ptr<CK2::Province>> toReturn;
 	for (const auto& province: theClaims[winner])
 	{

--- a/CK2ToEU4Tests/CK2WorldTests/Titles/TitleTests.cpp
+++ b/CK2ToEU4Tests/CK2WorldTests/Titles/TitleTests.cpp
@@ -449,3 +449,32 @@ TEST(CK2World_TitleTests, ColorCanBeLoaded)
 	ASSERT_EQ(theTitle.getColor().g(), 5);
 	ASSERT_EQ(theTitle.getColor().b(), 6);
 }
+
+TEST(CK2World_TitleTests, electorsDefaultToEmpty)
+{
+	std::stringstream input;
+	input << "=\n";
+	input << "{\n";
+	input << "}";
+
+	const CK2::Title theTitle(input, "c_test");
+
+	ASSERT_TRUE(theTitle.getElectors().empty());
+}
+
+TEST(CK2World_TitleTests, electorsCanBeSet)
+{
+	std::stringstream input;
+	input << "=\n";
+	input << "{\n";
+	input << "\tsuccession_electors = { 1 2 3 }\n";
+	input << "}";
+
+	const CK2::Title theTitle(input, "c_test");
+
+	ASSERT_EQ(theTitle.getElectors().size(), 3);
+	ASSERT_TRUE(theTitle.getElectors().count(1));
+	ASSERT_TRUE(theTitle.getElectors().count(2));
+	ASSERT_TRUE(theTitle.getElectors().count(3));
+}
+


### PR DESCRIPTION
- Importing historical HRE electors if at all possible.
- Not assigning Free Cities to electors and not assigning electorates to Free Cities