### PR TITLE
Vinland and Mods

### DIFF
--- a/CK2ToEU4/Data_Files/configurables/culture_map.txt
+++ b/CK2ToEU4/Data_Files/configurables/culture_map.txt
@@ -343,3 +343,23 @@ link = { eu4 = dog_culture ck2 = dog_culture tech = western gfx = westerngfx }
 link = { eu4 = elephant_culture ck2 = elephant_culture tech = western gfx = westerngfx }
 link = { eu4 = dragon_culture ck2 = dragon_culture tech = western gfx = westerngfx }
 link = { eu4 = red_panda ck2 = red_panda tech = eastern gfx = easterngfx }
+
+# ---- SUPPORTED MODS ----- Sons of Vinland
+link = { eu4 = inuit ck2 = tuniq tech = north_american gfx = northamericagfx}
+link = { eu4 = inuit ck2 = inuit tech = north_american gfx = northamericagfx}
+link = { eu4 = cree ck2 = innu tech = north_american gfx = northamericagfx}
+link = { eu4 = cree ck2 = atikamekw tech = north_american gfx = northamericagfx}
+link = { eu4 = inuit ck2 = beothuk tech = north_american gfx = northamericagfx}
+link = { eu4 = anishinabe ck2 = anishinabe tech = north_american gfx = northamericagfx}
+link = { eu4 = shawnee ck2 = shawnee tech = north_american gfx = northamericagfx}
+link = { eu4 = mikmaq ck2 = mikmaq tech = north_american gfx = northamericagfx}
+link = { eu4 = abenaki ck2 = abenaki tech = north_american gfx = northamericagfx}
+link = { eu4 = pequot ck2 = pequot tech = north_american gfx = northamericagfx}
+link = { eu4 = powhatan ck2 = powhatan tech = north_american gfx = northamericagfx}
+link = { eu4 = mahican ck2 = mahican tech = north_american gfx = northamericagfx}
+link = { eu4 = delaware ck2 = delaware tech = north_american gfx = northamericagfx}
+link = { eu4 = iroquois ck2 = iroquois tech = north_american gfx = northamericagfx}
+link = { eu4 = huron ck2 = kanata tech = north_american gfx = northamericagfx}
+link = { eu4 = susquehannock ck2 = susquehannock tech = north_american gfx = northamericagfx}
+link = { eu4 = cherokee ck2 = cherokee tech = north_american gfx = northamericagfx}
+

--- a/CK2ToEU4/Data_Files/configurables/government_map.txt
+++ b/CK2ToEU4/Data_Files/configurables/government_map.txt
@@ -79,5 +79,5 @@ link = { title = d_hurufi gov = monarchy reform = feudal_theocracy }
 link = { title = d_qarmatian gov = monarchy reform = feudal_theocracy }
 link = { title = d_mamluks gov = monarchy reform = mamluk_government }
 
-
-
+# ---- SUPPORTED MODS ----- Sons of Vinland
+link = { gov = tribal ck2gov = amerindian_tribal_government }

--- a/CK2ToEU4/Data_Files/configurables/province_mappings.txt
+++ b/CK2ToEU4/Data_Files/configurables/province_mappings.txt
@@ -1353,4 +1353,47 @@
 	link = { ck2 = 1920 ck2 = 1925 ck2 = 1924 eu4 = 4668 }	# Orkhon, Tuul, Chikoi -> West Ih Huree
 	link = { ck2 = 1923 eu4 = 4220 eu4 = 2116 }	# Khilok -> Khiagt, Ih Huree
 	link = { ck2 = 1921 ck2 = 1460 ck2 = 1922 eu4 = 1057 }	# Selenge, Baygal, Uda -> Ude
+	
+	# ---- SUPPORTED MODS ----- Sons of Vinland - North America / Canada
+	link = { ck2 = 2331 eu4 = 1104 } #kujalleq
+	link = { ck2 = 3510 eu4 = 1105 } #ivittuut
+	link = { ck2 = 3333 ck2 = 3535 eu4 = 2574 } #agvituk sheshatshiu
+	link = { ck2 = 3336 eu4 = 997 } #pakuashipi
+	link = { ck2 = 3532 eu4 = 2574 } #nunajnguk
+	link = { ck2 = 3542 ck = 3543 eu4 = 981 } #maqtukwek, siinalk
+	link = { ck2 = 3544 eu4 = 980 } #beothuk
+	link = { ck2 = 3545 eu4 = 2573 } #wabana
+	link = { ck2 = 3537 eu4 = 996 } #unamenshipit
+	link = { ck2 = 3538 eu4 = 2576 } #uashat
+	link = { ck2 = 3556 eu4 = 2578 } #natigosteg
+	link = { ck2 = 3539 eu4 = 2577 } #pessamit
+	link = { ck2 = 3540 eu4 = 995} #chicoutimi
+	link = { ck2 = 3540 ck2 = 3539 eu4 = 2579 } #pessamit chicoutimi
+	link = { ck2 = 3541 eu4 = 2580 } #nitaskinan
+	link = { ck2 = 3615 eu4 = 994 } #stadacona
+	link = { ck2 = 3653 eu4 = 990 } #hochelaga
+	link = { ck2 = 3547 eu4 = 982 } #unamakik
+	link = { ck2 = 3548 eu4 = 983 } #epekwitk
+	link = { ck2 = 3550 eu4 = 984 } #piktuk
+	link = { ck2 = 3551 ck2 = 3552 eu4 = 2569 } #eskikewakik sipeknikatik
+	link = { ck2 = 3553 eu4 = 2568 } #kespukwitk
+	link = { ck2 = 3554 eu4 = 985 } #siknikt
+	link = { ck2 = 3555 eu4 = 986 } #kespek
+	link = { ck2 = 3554 ck2 = 3555 eu4 = 2572 }#siknikt kespek
+	link = { ck2 = 3605 eu4 = 2570 } #wolystoq
+	link = { ck2 = 3606 eu4 = 2571 } #madawaska
+	link = { ck2 = 3607 eu4 = 2582 } #maliseet
+	link = { ck2 = 3608 eu4 = 2567 } #aroostook
+	link = { ck2 = 3609 eu4 = 2566 } #passamaquoddy
+	link = { ck2 = 3610 eu4 = 971 eu4 = 2565 }#penobscott
+	link = { ck2 = 3611 eu4 = 2013} #androscoggin
+	link = { ck2 = 3613 eu4 = 2012} #arsigantegok 
+	link = { ck2 = 3614 eu4 = 2583} #etchemins 
+	link = { ck2 = 3617 eu4 = 2584} #loup
+	link = { ck2 = 3619 eu4 = 970 eu4 = 2562} #merrimack
+	link = { ck2 = 3621 eu4 = 2563 eu4 = 2564} #missiquoi 
+	link = { ck2 = 3623 eu4 = 2559 } #adirondack
+	link = { ck2 = 3625 eu4 = 963 eu4 = 969} #mahican
+	link = { ck2 = 3627 eu4 = 2561 eu4 = 968 eu4 = 966} #wampanoag
+	link = { ck2 = 3631 eu4 = 967 eu4 = 2010 eu4 = 965 eu4 = 2560} #manhattan
 }

--- a/CK2ToEU4/Data_Files/configurables/religion_map.txt
+++ b/CK2ToEU4/Data_Files/configurables/religion_map.txt
@@ -74,3 +74,9 @@ link = { ck2 = buddhist eu4 = buddhism }
 link = { ck2 = hindu eu4 = hinduism }
 link = { ck2 = jain eu4 = jain }
 link = { ck2 = taoist eu4 = confucianism }
+
+# ---- SUPPORTED MODS ----- Sons of Vinland
+link = { ck2 = inuit_pagan eu4 = totemism}
+link = { ck2 = inuit_pagan_reformed eu4 = totemismm}
+link = { ck2 = algic_pagan eu4 = totemism}
+link = { ck2 = algic_pagan_reformed eu4 = totemism}

--- a/CK2ToEU4/Source/CK2World/World.cpp
+++ b/CK2ToEU4/Source/CK2World/World.cpp
@@ -159,9 +159,6 @@ CK2::World::World(const Configuration& theConfiguration)
 	LOG(LogLevel::Info) << "-- Linking The Celestial Emperor";
 	linkCelestialEmperor();
 
-	// Intermezzo
-	verifyReligionsAndCultures(theConfiguration);
-
 	// Filter top-tier active titles and assign them provinces.
 	LOG(LogLevel::Info) << "-- Merging Independent Baronies";
 	mergeIndependentBaronies();
@@ -350,62 +347,6 @@ void CK2::World::alterSunset(const Configuration& theConfiguration)
 	else if (theConfiguration.getSunset() == Configuration::SUNSET::DISABLED)
 		invasion = false;
 }
-
-void CK2::World::verifyReligionsAndCultures(const Configuration& theConfiguration)
-{
-	auto insanityCounter = 0;
-	LOG(LogLevel::Info) << "-- Verifyling All Characters Have Religion And Culture Loaded";
-	for (const auto& character: characters.getCharacters())
-	{
-		if (character.second->getReligion().empty() || character.second->getCulture().empty())
-			insanityCounter++;
-	}
-	if (!insanityCounter)
-	{
-		Log(LogLevel::Info) << "<> All " << characters.getCharacters().size() << "characters are sane.";
-		return;
-	}
-	Log(LogLevel::Warning) << "! " << insanityCounter << " characters have lacking definitions! Attempting recovery.";
-	loadDynastiesFromMods(theConfiguration);
-}
-
-void CK2::World::loadDynastiesFromMods(const Configuration& theConfiguration)
-{
-	LOG(LogLevel::Info) << "*** Intermezzo ***";
-	Log(LogLevel::Info) << "-> Rummaging through mods in search of definitions.";
-	bool weAreSane = false;
-	for (const auto& mod: mods.getMods())
-	{
-		if (Utils::doesFolderExist(mod.second + "/common/dynasties/"))
-		{
-			Log(LogLevel::Info) << "Found something interesting in " << mod.first;
-			std::set<std::string> fileNames;
-			Utils::GetAllFilesInFolder(mod.second + "/common/dynasties/", fileNames);
-			for (const auto& file: fileNames)
-				dynasties.underLoadDynasties(mod.second + "/common/dynasties/" + file);
-		}
-		else
-			continue;
-		auto insanityCounter = 0;
-		for (const auto& character: characters.getCharacters())
-		{
-			if (character.second->getReligion().empty() || character.second->getCulture().empty())
-				insanityCounter++;
-		}
-		if (!insanityCounter)
-		{
-			Log(LogLevel::Info) << "<> All " << characters.getCharacters().size() << " characters have been sanified. Cancelling rummage.";
-			weAreSane = true;
-			break;
-		}
-		Log(LogLevel::Warning) << "! " << insanityCounter << " characters are still lacking definitions. Continuing with the rummage.";
-	}
-
-	if (!weAreSane)
-		LOG(LogLevel::Warning) << "... We did what we could.";
-	LOG(LogLevel::Info) << "*** Intermezzo End, back to scheduled run ***";
-}
-
 
 void CK2::World::linkCelestialEmperor() const
 {

--- a/CK2ToEU4/Source/CK2World/World.h
+++ b/CK2ToEU4/Source/CK2World/World.h
@@ -58,8 +58,6 @@ class World: commonItems::parser
 	void resolveTanistry(const std::string& genderLaw, const std::pair<int, std::shared_ptr<Character>>& holder) const;
 	void resolveTurkish(const std::pair<int, std::shared_ptr<Character>>& holder) const;
 	void linkCelestialEmperor() const;
-	void verifyReligionsAndCultures(const Configuration& theConfiguration);
-	void loadDynastiesFromMods(const Configuration& theConfiguration);
 	void linkElectors();
 	void loadDynasties(const Configuration& theConfiguration);
 	void loadProvinces(const Configuration& theConfiguration);

--- a/CK2ToEU4/Source/CK2World/World.h
+++ b/CK2ToEU4/Source/CK2World/World.h
@@ -35,7 +35,7 @@ class World: commonItems::parser
 	[[nodiscard]] const auto& getOffmaps() const { return offmaps; }
 	[[nodiscard]] const auto& getDiplomacy() const { return diplomacy; }
 	[[nodiscard]] const auto& getVars() const { return vars; }
-
+	[[nodiscard]] const auto& getMods() const { return mods; }
 	[[nodiscard]] auto isInvasion() const { return (invasion); }
 
   private:
@@ -61,6 +61,8 @@ class World: commonItems::parser
 	void verifyReligionsAndCultures(const Configuration& theConfiguration);
 	void loadDynastiesFromMods(const Configuration& theConfiguration);
 	void linkElectors();
+	void loadDynasties(const Configuration& theConfiguration);
+	void loadProvinces(const Configuration& theConfiguration);
 
 	bool invasion = false;
 	date endDate = date("1444.11.11");

--- a/CK2ToEU4/Source/EU4World/Country/Country.cpp
+++ b/CK2ToEU4/Source/EU4World/Country/Country.cpp
@@ -561,9 +561,9 @@ void EU4::Country::initializeRulers(const mappers::ReligionMapper& religionMappe
 	}
 	if (holder->getDynasty().first)
 		details.monarch.dynasty = holder->getDynasty().second->getName();
-	details.monarch.adm = std::min((holder->getSkills().stewardship + holder->getSkills().learning) / 4, 6);
-	details.monarch.dip = std::min((holder->getSkills().diplomacy + holder->getSkills().intrigue) / 4, 6);
-	details.monarch.mil = std::min((holder->getSkills().martial + holder->getSkills().learning) / 4, 6);
+	details.monarch.adm = std::min((holder->getSkills().stewardship + holder->getSkills().learning) / 3, 6);
+	details.monarch.dip = std::min((holder->getSkills().diplomacy + holder->getSkills().intrigue) / 3, 6);
+	details.monarch.mil = std::min((holder->getSkills().martial + holder->getSkills().learning) / 3, 6);
 	details.monarch.birthDate = holder->getBirthDate();
 	details.monarch.female = holder->isFemale();
 	// religion and culture were already determining our country's primary culture and religion. If we set there, we'll copy here.
@@ -584,9 +584,9 @@ void EU4::Country::initializeRulers(const mappers::ReligionMapper& religionMappe
 			details.queen.name = spouse.second->getName();
 			if (spouse.second->getDynasty().first)
 				details.queen.dynasty = spouse.second->getDynasty().second->getName();
-			details.queen.adm = std::min((spouse.second->getSkills().stewardship + spouse.second->getSkills().learning) / 4, 6);
-			details.queen.dip = std::min((spouse.second->getSkills().diplomacy + spouse.second->getSkills().intrigue) / 4, 6);
-			details.queen.mil = std::min((spouse.second->getSkills().martial + spouse.second->getSkills().learning) / 4, 6);
+			details.queen.adm = std::min((spouse.second->getSkills().stewardship + spouse.second->getSkills().learning) / 3, 6);
+			details.queen.dip = std::min((spouse.second->getSkills().diplomacy + spouse.second->getSkills().intrigue) / 3, 6);
+			details.queen.mil = std::min((spouse.second->getSkills().martial + spouse.second->getSkills().learning) / 3, 6);
 			details.queen.birthDate = spouse.second->getBirthDate();
 			details.queen.female = spouse.second->isFemale();
 			if (spouse.second->getReligion().empty())
@@ -637,9 +637,9 @@ void EU4::Country::initializeRulers(const mappers::ReligionMapper& religionMappe
 		}
 		if (heir.second->getDynasty().first)
 			details.heir.dynasty = heir.second->getDynasty().second->getName();
-		details.heir.adm = std::min((heir.second->getSkills().stewardship + heir.second->getSkills().learning) / 3, 6);
-		details.heir.dip = std::min((heir.second->getSkills().diplomacy + heir.second->getSkills().intrigue) / 3, 6);
-		details.heir.mil = std::min((heir.second->getSkills().martial + heir.second->getSkills().learning) / 3, 6);
+		details.heir.adm = std::min((heir.second->getSkills().stewardship + heir.second->getSkills().learning) / 2, 6);
+		details.heir.dip = std::min((heir.second->getSkills().diplomacy + heir.second->getSkills().intrigue) / 2, 6);
+		details.heir.mil = std::min((heir.second->getSkills().martial + heir.second->getSkills().learning) / 2, 6);
 		details.heir.birthDate = heir.second->getBirthDate();
 		details.heir.female = heir.second->isFemale();
 		if (heir.second->getReligion().empty())

--- a/CK2ToEU4/Source/EU4World/EU4World.cpp
+++ b/CK2ToEU4/Source/EU4World/EU4World.cpp
@@ -485,7 +485,7 @@ void EU4::World::distributeForts()
 void EU4::World::alterProvinceDevelopment()
 {
 	Log(LogLevel::Info) << "-- Scaling Imported provinces";
-	// For every 12 buildings in a province we assign a dev point (barony itself counts as 3).
+	// For every 10 buildings in a province we assign a dev point (barony itself counts as 3).
 	// We adhere to the distribution key:
 	// castle: 2/3 mil 1/3 adm
 	// city: dip
@@ -514,20 +514,20 @@ void EU4::World::alterProvinceDevelopment()
 			const auto buildingNumber = static_cast<double>(barony.second->getBuildingCount());
 			if (barony.second->getType() == "tribal" || barony.second->getType() == "nomad")
 			{
-				mil += lround((3 + buildingNumber) / 12);
+				mil += lround((3 + buildingNumber) / 10);
 			}
 			else if (barony.second->getType() == "city")
 			{
-				dip += lround((3 + buildingNumber) / 12);
+				dip += lround((3 + buildingNumber) / 10);
 			}
 			else if (barony.second->getType() == "temple")
 			{
-				adm += lround((3 + buildingNumber) / 12);
+				adm += lround((3 + buildingNumber) / 10);
 			}
 			else if (barony.second->getType() == "castle")
 			{
-				adm += lround((3 + buildingNumber) / 48); // third to adm
-				mil += lround((3 + buildingNumber) / 18); // two thirds to mil
+				adm += lround((3 + buildingNumber) / 30); // third to adm
+				mil += lround((3 + buildingNumber) / 15); // two thirds to mil
 			}
 		}
 		province.second->setAdm(std::max(adm, 1));

--- a/CK2ToEU4/Source/EU4World/EU4World.h
+++ b/CK2ToEU4/Source/EU4World/EU4World.h
@@ -38,7 +38,7 @@ class World
 	void importCK2Countries(const CK2::World& sourceWorld);
 	void importCK2Country(const std::pair<std::string, std::shared_ptr<CK2::Title>>& title, const CK2::World& sourceWorld);
 	void importCK2Provinces(const CK2::World& sourceWorld);
-	void output(const mappers::VersionParser& versionParser, const Configuration& theConfiguration, date conversionDate, bool invasion) const;
+	void output(const mappers::VersionParser& versionParser, const Configuration& theConfiguration, const CK2::World& sourceWorld) const;
 	void createModFile(const Configuration& theConfiguration) const;
 	void outputVersion(const mappers::VersionParser& versionParser, const Configuration& theConfiguration) const;
 	void outputCommonCountriesFile(const Configuration& theConfiguration) const;
@@ -48,7 +48,7 @@ class World
 	void outputLocalization(const Configuration& theConfiguration, bool invasion) const;
 	void verifyReligionsAndCultures();
 	void linkProvincesToCountries();
-	void outputFlags(const Configuration& theConfiguration, bool invasion) const;
+	void outputFlags(const Configuration& theConfiguration, const CK2::World& sourceWorld) const;
 	void outputBookmark(const Configuration& theConfiguration, date conversionDate) const;
 	void distributeHRESubtitles(const Configuration& theConfiguration);
 	void outputEmperor(const Configuration& theConfiguration, date conversionDate) const;
@@ -65,6 +65,7 @@ class World
 	void fixTengri();
 	void siberianQuestion(const Configuration& theConfiguration);
 	void distributeClaims();
+	void scrapeColors(const Configuration& theConfiguration, const CK2::World& sourceWorld);
 
 	[[nodiscard]] std::optional<std::pair<int, std::shared_ptr<CK2::Province>>> determineProvinceSource(const std::vector<int>& ck2ProvinceNumbers,
 		 const CK2::World& sourceWorld) const;

--- a/CK2ToEU4/Source/Mappers/ColorScraper/ColorScraper.cpp
+++ b/CK2ToEU4/Source/Mappers/ColorScraper/ColorScraper.cpp
@@ -4,11 +4,9 @@
 
 void mappers::ColorScraper::scrapeColors(const std::string& filePath)
 {
-	LOG(LogLevel::Info) << "-> Soaking Up Colors";
 	registerKeys();
 	parseFile(filePath);
 	clearRegisteredKeywords();
-	LOG(LogLevel::Info) << ">> " << titleColors.size() << " colors soaked up.";
 }
 
 void mappers::ColorScraper::scrapeColors(std::istream& theStream, std::string theName)
@@ -26,7 +24,13 @@ void mappers::ColorScraper::registerKeys()
 		ColorScraper newScraper;
 		newScraper.scrapeColors(theStream, titleName);
 		auto foundColors = newScraper.getColors();
-		titleColors.insert(foundColors.begin(), foundColors.end());
+		for (const auto& foundColor: foundColors)
+		{
+			if (titleColors.count(foundColor.first))
+				titleColors[foundColor.first] = foundColor.second; // Overwriting for mod sources
+			else
+				titleColors.insert(foundColors.begin(), foundColors.end());
+		}
 	});
 
 	registerRegex("color", [this](const std::string& unused, std::istream& theStream) {

--- a/CK2ToEU4/Source/Mappers/LocalizationMapper/LocalizationMapper.cpp
+++ b/CK2ToEU4/Source/Mappers/LocalizationMapper/LocalizationMapper.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <set>
 
-void mappers::LocalizationMapper::scrapeLocalizations(const Configuration& theConfiguration)
+void mappers::LocalizationMapper::scrapeLocalizations(const Configuration& theConfiguration, const std::map<std::string, std::string>& mods)
 {
 	LOG(LogLevel::Info) << "-> Reading Words";
 	std::set<std::string> filenames;
@@ -16,6 +16,23 @@ void mappers::LocalizationMapper::scrapeLocalizations(const Configuration& theCo
 		scrapeStream(theFile);
 		theFile.close();
 	}
+	for (const auto& mod: mods)
+	{
+		if (Utils::doesFolderExist(mod.second + "/localisation/"))
+		{
+			Log(LogLevel::Info) << "\t>> Found some words in: " << mod.second + "/localization/";
+			filenames.clear();
+			Utils::GetAllFilesInFolder(mod.second + "/localisation/", filenames);
+			for (const auto& file: filenames)
+			{
+				if (file.find(".csv") == std::string::npos) continue;
+				std::ifstream theFile(mod.second + "/localisation/" + file);
+				scrapeStream(theFile);
+				theFile.close();
+			}			
+		}
+	}
+	
 	// Override with our keys
 	if (Utils::DoesFileExist("configurables/ck2_localization_override.csv"))
 	{

--- a/CK2ToEU4/Source/Mappers/LocalizationMapper/LocalizationMapper.h
+++ b/CK2ToEU4/Source/Mappers/LocalizationMapper/LocalizationMapper.h
@@ -19,7 +19,7 @@ class LocalizationMapper
 {
   public:
 	LocalizationMapper() = default;
-	void scrapeLocalizations(const Configuration& theConfiguration);
+	void scrapeLocalizations(const Configuration& theConfiguration, const std::map<std::string, std::string>& mods);
 	void scrapeStream(std::istream& theStream);
 
 	[[nodiscard]] std::optional<LocBlock> getLocBlockForKey(const std::string& key) const;


### PR DESCRIPTION
* Mods are now rummaged from getgo and we're assuming "all mods on disk are enabled for all games"

While nominally a dangerous assumption, we're not affecting or loading a lot - provinces are added if any exist (and need to be enabled in mappings to have any effect), dynasties we need anyway and unused dynasties don't hurt us,  more localization is always good, and ditto for any potential flag sources.

* More generous development map (10 buildings for dev point, down from 12) - europe looked like a wasteland most of the time
* More generous ruler stats (divide by 3 instead of 4, heirs by 2 instead of 3) - as we don't take inherent bonuses into account like genius etc.

* Added mappings for Sons of Vinland - a Canada expansion mod