### PR TITLE
Coat of Arms religion takes precedence over Base religion

### DIFF
--- a/CK2ToEU4/Source/CK2World/Characters/Character.cpp
+++ b/CK2ToEU4/Source/CK2World/Characters/Character.cpp
@@ -118,10 +118,14 @@ bool CK2::Character::hasTrait(const std::string& wantedTrait) const
 
 const std::string& CK2::Character::getReligion() const
 {
-	if (!religion.empty())
-		return religion;
-	if (dynasty.first && !dynasty.second->getReligion().empty())
-		return dynasty.second->getReligion();
+	// The CK2 save omits the character religion in the case where the character religion matches the dynasty religion.
+	if (religion.empty() && dynasty.second)
+	{
+		const std::string& dynastyReligion = dynasty.second->getReligion();
+		if (!dynastyReligion.empty())
+			return dynastyReligion;
+	}
+
 	return religion;
 }
 
@@ -129,7 +133,7 @@ const std::string& CK2::Character::getCulture() const
 {
 	if (!culture.empty())
 		return culture;
-	if (dynasty.first && !dynasty.second->getCulture().empty())
+	if (dynasty.second && !dynasty.second->getCulture().empty())
 		return dynasty.second->getCulture();
 	return culture;
 }

--- a/CK2ToEU4/Source/CK2World/Characters/Character.cpp
+++ b/CK2ToEU4/Source/CK2World/Characters/Character.cpp
@@ -121,7 +121,7 @@ const std::string& CK2::Character::getReligion() const
 	// The CK2 save omits the character religion in the case where the character religion matches the dynasty religion.
 	if (religion.empty() && dynasty.second)
 	{
-		const std::string& dynastyReligion = dynasty.second->getReligion();
+		const auto& dynastyReligion = dynasty.second->getReligion();
 		if (!dynastyReligion.empty())
 			return dynastyReligion;
 	}

--- a/CK2ToEU4/Source/CK2World/Dynasties/Dynasty.cpp
+++ b/CK2ToEU4/Source/CK2World/Dynasties/Dynasty.cpp
@@ -65,8 +65,8 @@ void CK2::Dynasty::registerUnderKeys()
 
 const std::string& CK2::Dynasty::getReligion() const
 {
-	if (!religion.empty())
-		return religion;
+	// CK2 seems to prefer the dynasty religion in the coat_of_arms section. As such we only
+	// fall back to the nominal dynasty religion if there's no religion in the coat_of_arms section.
 	if (!coa.getReligion().empty())
 		return coa.getReligion();
 	return religion;


### PR DESCRIPTION
Running through various CK2 saves and comparing the religion detail in the save file against the character's religion in-game, we see that that the fallback in the case where the religion in the character section is not included is to use the religion in the dynasty's _coat_of_arms_ section rather than the religion in the dynasty's main section. The religions of all CK2 rulers and EU4 countries seem to match now in the converted saves that I tested.