### PR TITLE
Only use dynasty flags if the tag has a dynasty name.

### DIFF
--- a/CK2ToEU4/Source/EU4World/Country/Country.cpp
+++ b/CK2ToEU4/Source/EU4World/Country/Country.cpp
@@ -267,6 +267,7 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		newblock.french = dynastyName;
 		newblock.german = dynastyName;
 		localizations.insert(std::pair(tag, newblock));
+		dynastyFlag = true;
 		nameSet = true;
 	}
 	if (!nameSet && !title.second->getDisplayName().empty())

--- a/CK2ToEU4/Source/EU4World/Country/Country.h
+++ b/CK2ToEU4/Source/EU4World/Country/Country.h
@@ -66,6 +66,7 @@ class Country
 	[[nodiscard]] auto isinHRE() const { return details.inHRE; }
 	[[nodiscard]] auto getCapitalID() const { return details.capital; }
 	[[nodiscard]] auto getDynastyID() const { return details.dynastyID; }
+	[[nodiscard]] auto useDynastyFlag() const { return dynastyFlag; }
 
 	[[nodiscard]] int getDevelopment() const;
 
@@ -97,6 +98,7 @@ class Country
 	std::string historyCountryFile;
 	date conversionDate; // for dating the monarchs in history file.
 	CountryDetails details;
+	bool dynastyFlag = false; // Should the converter try to use a dynasty flag (if one is available)?
 
 	std::pair<std::string, std::shared_ptr<CK2::Title>> title;
 	std::map<std::string, mappers::LocBlock> localizations;

--- a/CK2ToEU4/Source/EU4World/Output/outWorld.cpp
+++ b/CK2ToEU4/Source/EU4World/Output/outWorld.cpp
@@ -13,7 +13,7 @@ void EU4::World::output(const mappers::VersionParser& versionParser, const Confi
 	const auto invasion = sourceWorld.isInvasion();
 	const date conversionDate = sourceWorld.getConversionDate();
 	LOG(LogLevel::Info) << "<- Creating Output Folder";
-	
+
 	Utils::TryCreateFolder("output");
 	if (Utils::DoesFolderExist("output/" + theConfiguration.getOutputName()))
 	{
@@ -154,7 +154,8 @@ void EU4::World::outputFlags(const Configuration& theConfiguration, const CK2::W
 	for (const auto& country: countries)
 	{
 		// first check is for dynasty and override flags.
-		if (country.second->getDynastyID() && Utils::DoesFileExist("configurables/dynastyflags/" + std::to_string(country.second->getDynastyID()) + ".tga"))
+		if (country.second->useDynastyFlag() && country.second->getDynastyID() &&
+			 Utils::DoesFileExist("configurables/dynastyflags/" + std::to_string(country.second->getDynastyID()) + ".tga"))
 		{
 			Utils::TryCopyFile("configurables/dynastyflags/" + std::to_string(country.second->getDynastyID()) + ".tga",
 				 "output/" + theConfiguration.getOutputName() + "/gfx/flags/" + country.first + ".tga");


### PR DESCRIPTION
Also, override when copying the flag.