### PR TITLE
Fixes to HRE emperorship

### DIFF
--- a/CK2ToEU4/Source/CK2World/Provinces/Province.cpp
+++ b/CK2ToEU4/Source/CK2World/Provinces/Province.cpp
@@ -53,3 +53,23 @@ int CK2::Province::getBuildingWeight() const
 	}
 	return buildingWeight;
 }
+
+std::optional<std::pair<std::string, std::shared_ptr<CK2::Title>>> CK2::Province::belongsToDuchy() const
+{
+	if (deJureTitle.second && deJureTitle.second->getLiege().second && deJureTitle.second->getLiege().second->getTitle().second &&
+		 deJureTitle.second->getLiege().second->getTitle().first.find("d_") == 0)
+		return deJureTitle.second->getLiege().second->getTitle();
+	else
+		return std::nullopt;
+}
+
+std::optional<std::pair<std::string, std::shared_ptr<CK2::Title>>> CK2::Province::belongsToKingdom() const
+{
+	if (deJureTitle.second && deJureTitle.second->getLiege().second && deJureTitle.second->getLiege().second->getTitle().second &&
+		 deJureTitle.second->getLiege().second->getTitle().second->getLiege().second &&
+		 deJureTitle.second->getLiege().second->getTitle().second->getLiege().second->getTitle().second && 
+		 deJureTitle.second->getLiege().second->getTitle().second->getLiege().second->getTitle().first.find("k_") == 0)
+		return deJureTitle.second->getLiege().second->getTitle().second->getLiege().second->getTitle();
+	else
+		return std::nullopt;
+}

--- a/CK2ToEU4/Source/CK2World/Provinces/Province.h
+++ b/CK2ToEU4/Source/CK2World/Provinces/Province.h
@@ -27,10 +27,13 @@ class Province: commonItems::parser
 	[[nodiscard]] auto getBaronyCount() const { return static_cast<int>(baronies.size()); }
 
 	[[nodiscard]] int getBuildingWeight() const;
+	[[nodiscard]] std::optional<std::pair<std::string, std::shared_ptr<Title>>> belongsToDuchy() const; // defacto
+	[[nodiscard]] std::optional<std::pair<std::string, std::shared_ptr<Title>>> belongsToKingdom() const; // defacto
 
 	void discardPrimarySettlement() { primarySettlement.first.clear(); }
 	void setPrimarySettlement(std::shared_ptr<Barony> theBarony) { primarySettlement.second = std::move(theBarony); }
 	void loadHoldingTitle(const std::pair<std::string, std::shared_ptr<Title>>& theTitle) { title = theTitle; }
+	void loadDeJureTitle(const std::pair<std::string, std::shared_ptr<Title>>& theDeJureTitle) { deJureTitle = theDeJureTitle; }
 	void loadWonder(const std::pair<int, std::shared_ptr<Wonder>>& theWonder) { wonder = theWonder; }
 	void setDeJureHRE() { deJureHRE = true; }
 
@@ -44,7 +47,8 @@ class Province: commonItems::parser
 	std::string religion;
 	std::string name;
 	std::pair<std::string, std::shared_ptr<Barony>> primarySettlement;
-	std::pair<std::string, std::shared_ptr<Title>> title;
+	std::pair<std::string, std::shared_ptr<Title>> title; // owner title (e_francia or similar)
+	std::pair<std::string, std::shared_ptr<Title>> deJureTitle; // county (c_paris)
 	std::pair<int, std::shared_ptr<Wonder>> wonder;
 	std::map<std::string, std::shared_ptr<Barony>> baronies;
 };

--- a/CK2ToEU4/Source/CK2World/Titles/Titles.cpp
+++ b/CK2ToEU4/Source/CK2World/Titles/Titles.cpp
@@ -202,6 +202,7 @@ void CK2::Titles::linkProvinces(const Provinces& theProvinces, const mappers::Pr
 			{
 				title.second->registerProvince(std::pair(provinceItr->second->getID(), provinceItr->second));
 				title.second->registerDeJureProvince(std::pair(provinceItr->second->getID(), provinceItr->second));
+				provinceItr->second->loadDeJureTitle(title);
 				counter++;
 			}
 			else

--- a/CK2ToEU4/Source/EU4World/EU4World.cpp
+++ b/CK2ToEU4/Source/EU4World/EU4World.cpp
@@ -1014,17 +1014,17 @@ void EU4::World::resolvePersonalUnions()
 		{
 			// We need to find another primary title.
 			auto foundPrimary = false;
-			// First check if we can find PAP or FAP
+			// First check if we can find PAP or FAP or some special flag
 			for (const auto& title: holderTitle.second)
 			{
-				if (title.first == "PAP" || title.first == "FAP")
+				if (title.first == "PAP" || title.first == "FAP" || title.second->isHREEmperor() || title.second->isHREElector())
 				{
 					primaryTitle = std::pair(title.first, title.second);
 					foundPrimary = true;
 					break;
 				}
 			}
-			// If no popes pick first one.
+			// If no popes or specials pick first one.
 			if (!foundPrimary)
 				for (const auto& title: holderTitle.second)
 				{


### PR DESCRIPTION
- Since emperor is likely to have multiple duchies, we're looking to set primary the one containing his capital
- failing that we'll fallback on previous eeny-miney-moe method
- baronies no longer qualify to become the emperor.
- when distributing PUs, the tag flagged as emperor/elector will automatically become serior, no longer pushing emperorship/electorship into junior PUs.