### PR TITLE
Official HRE shattering mode

### DIFF
--- a/CK2ToEU4/Data_Files/blankMod/output/common/religions/01_converted_religions.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/religions/01_converted_religions.txt
@@ -143,8 +143,10 @@ pagan = {
 		country_as_secondary = {
 			development_cost = -0.1
 		}
-		
-		heretic = { GOAT_SKULL }	
+
+		personal_deity = yes
+
+		heretic = { GOAT_SKULL }
 	}
 	hellenic_pagan_reformed = {
 		icon = 58
@@ -156,8 +158,10 @@ pagan = {
 		country_as_secondary = {
 			development_cost = -0.1
 		}
-		
-		heretic = { GOAT_SKULL }	
+
+		personal_deity = yes
+
+		heretic = { GOAT_SKULL }
 	}
 }
 

--- a/CK2ToEU4/Data_Files/blankMod/output/common/religions/01_converted_religions.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/religions/01_converted_religions.txt
@@ -138,10 +138,10 @@ pagan = {
 		color = { 0.6 0.1 0.1 }
 		country = {
 			tolerance_own = 1
-			development_cost = -0.1
+			development_cost = -0.05
 		}
 		country_as_secondary = {
-			development_cost = -0.1
+			development_cost = -0.05
 		}
 
 		personal_deity = yes

--- a/CK2ToEU4/Data_Files/blankMod/output/localisation/replace/converted_religions_l_english.yml
+++ b/CK2ToEU4/Data_Files/blankMod/output/localisation/replace/converted_religions_l_english.yml
@@ -41,3 +41,10 @@
  samaritan_faith: "Samaritan"
  karaite_faith: "Karaite"
  jain: "Jain"
+ jupiter: "Jupiter"
+ luno: "Luno"
+ neptunus: "Neptunus"
+ venus: "Venus"
+ mars: "Mars"
+ ceres: "Ceres"
+

--- a/CK2ToEU4/Source/CK2World/World.cpp
+++ b/CK2ToEU4/Source/CK2World/World.cpp
@@ -989,6 +989,17 @@ void CK2::World::flagHREProvinces(const Configuration& theConfiguration) const
 		return;
 	}
 
+	if (theConfiguration.getHRE() == Configuration::I_AM_HRE::OFFICIAL_LIKE)
+	{
+		const auto& allTitles = titles.getTitles();
+		const auto& hre = allTitles.find("e_hre");
+		if (hre->second->getLaws().count("law_voting_power_0")) // official like convert logic
+		{
+			Log(LogLevel::Info) << ">< HRE Provinces not available due to council power abolished.";
+			return;
+		}
+	}
+
 	std::string hreTitle;
 	switch (theConfiguration.getHRE())
 	{
@@ -1030,6 +1041,17 @@ void CK2::World::shatterHRE(const Configuration& theConfiguration) const
 	{
 		Log(LogLevel::Info) << ">< HRE Mechanics and shattering overridden by configuration.";
 		return;
+	}
+
+	if (theConfiguration.getHRE() == Configuration::I_AM_HRE::OFFICIAL_LIKE)
+	{
+		const auto& allTitles = titles.getTitles();
+		const auto& hre = allTitles.find("e_hre");
+		if (hre->second->getLaws().count("law_voting_power_0")) // official like convert logic
+		{
+			Log(LogLevel::Info) << ">< HRE Shattering disabled due to council power abolished.";
+			return;
+		}
 	}
 
 	std::string hreTitle;

--- a/CK2ToEU4/Source/Configuration/Configuration.h
+++ b/CK2ToEU4/Source/Configuration/Configuration.h
@@ -38,7 +38,8 @@ class Configuration: commonItems::parser
 		BYZANTIUM = 2,
 		ROME = 3,
 		CUSTOM = 4,
-		NONE = 5
+		NONE = 5,
+		OFFICIAL_LIKE = 6
 	};
 	enum class SHATTER_EMPIRES
 	{


### PR DESCRIPTION
If council power of HRE abolished,do not shatter HRE. like the official converter does.
But,abolish the council is too easy,maybe more conditions are needed.