### PR TITLE
Dynamic Ideas

### DIFF
--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_adm_custom_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_adm_custom_ideas.txt
@@ -1,0 +1,629 @@
+# cost = CFixedPoint( base_cost + ( level * level * level_cost ) ).GetTruncated()
+# DEFAULT: base_cost = 0, level_cost = 0.4, max_level = 4
+
+adm_idea_modifiers = {
+	category = ADM
+	
+	custom_idea_global_tax_modifier = {
+		global_tax_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		default = 2
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				technology_group = western
+			}
+		}
+	}		
+	custom_idea_production_efficiency = {
+		production_efficiency = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18		
+		default = 8
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				technology_group = sub_saharan
+			}
+		}
+	}
+	custom_idea_global_unrest = {
+		global_unrest = -0.5
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18			
+		default = 5
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+				mil = 3
+			}
+		}
+	}
+	custom_idea_stability_cost_modifier = {
+		stability_cost_modifier = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18		
+		default = 3		
+	}
+	custom_idea_missionaries = {
+		missionaries = 1
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 50
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0.75
+				NOT = {
+					any_owned_province = {
+						NOT = {
+							religion = ROOT
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 1.25
+				OR = {
+					government = theocracy
+					has_reform = holy_state_reform
+				}
+			}
+			modifier = {
+				factor = 0.9
+				OR = {
+					religion = waldensian
+					religion = paulician
+					religion = mazdaki
+					religion = manichean
+				}
+			}
+			modifier = {
+				factor = 0.7
+				religion = jainism
+			}
+			modifier = {
+				factor = 1.1
+				NOT = { dominant_religion = ROOT }
+				NOT = { has_reform = indian_sultanate_reform }
+			}
+			modifier = {
+				factor = 0.9
+				dominant_religion = ROOT
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					adm = 3
+				}
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					num_of_cities = 15
+				}
+			}
+			modifier = {
+				factor = 1.25
+				any_neighbor_country = {
+					NOT = { 
+						religion = ROOT
+					}
+					any_owned_province = { 
+						is_claim = ROOT 
+					}
+				}
+				mil = 3
+			}
+			modifier = {
+				factor = 1.25
+				any_neighbor_country = {
+					exists = yes
+				}
+				NOT = {
+					any_neighbor_country = {
+						religion = ROOT
+					}
+				}
+				mil = 3
+			}
+		}
+	}	
+	custom_idea_inflation_reduction = {
+		inflation_reduction = 0.05
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				gold = 1
+			}
+			modifier = {
+				factor = 1.1
+				gold = 2
+			}
+			modifier = {
+				factor = 1.1
+				gold = 3
+			}
+			modifier = {
+				factor = 1.1
+				gold = 4
+			}
+			modifier = {
+				factor = 1.1
+				gold = 5
+			}
+		}
+	}
+	custom_idea_inflation_action_cost = {
+		inflation_action_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}	
+	custom_idea_interest = {
+		interest = -0.5
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0.9
+				religion_group = christian
+			}
+		}
+	}	
+	custom_idea_build_cost = {
+		build_cost = -0.05
+		chance = {
+			factor = 1
+		}
+	}	
+	custom_idea_development_cost = {
+		development_cost = -0.1
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				any_owned_province = {
+					development = 20
+				}
+			}
+			modifier = {
+				factor = 1.3
+				NOT = { num_of_cities = 5 }
+			}
+		}
+	}
+	custom_idea_global_missionary_strength = {
+		global_missionary_strength = 0.005
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0.75
+				NOT = {
+					any_owned_province = {
+						NOT = {
+							religion = ROOT
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 1.25
+				OR = {
+					government = theocracy
+					has_reform = holy_state_reform
+				}
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					mil = 3
+				}
+			}
+			modifier = {
+				factor = 0.9
+				OR = {
+					religion = waldensian
+					religion = paulician
+					religion = mazdaki
+					religion = manichean
+				}
+			}
+			modifier = {
+				factor = 0.7
+				religion = jainism
+			}
+			modifier = {
+				factor = 1.1
+				religion = iconoclast
+			}
+			modifier = {
+				factor = 1.1
+				NOT = { religious_unity = 0.75 }
+				mil = 3
+				NOT = {
+					dip = 3
+				}
+			}
+			modifier = {
+				factor = 1.1
+				NOT = {
+					religion_group = muslim
+				}
+				any_owned_province = {
+					religion_group = muslim
+				}
+			}
+			modifier = {
+				factor = 1.1
+				NOT = {
+					religion = coptic
+				}
+				any_owned_province = {
+					religion_group = coptic
+				}
+			}
+			modifier = {
+				factor = 1.1
+				NOT = {
+					religion = monophysite
+				}
+				any_owned_province = {
+					religion_group = monophysite
+				}
+			}
+			modifier = {
+				factor = 1.1
+				NOT = {
+					religion = bogomilist
+				}
+				any_owned_province = {
+					religion_group = bogomilist
+				}
+			}
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = {
+					NOT = { 
+						religion = ROOT
+					}
+				}
+			}
+			modifier = {
+				factor = 1.1
+				NOT = {
+					dominant_religion = ROOT
+				}
+			}
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = {
+					exists = yes
+				}
+				NOT = {
+					any_neighbor_country = {
+						religion = ROOT
+					}
+				}
+			}
+		}
+	}	
+	custom_idea_prestige = {
+		prestige = 0.5	
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+				dip = 3
+			}
+		}
+	}
+	custom_idea_prestige_decay = {
+		prestige_decay = -0.005
+	}	
+	custom_idea_legitimacy = {
+		legitimacy = 0.5
+		level_cost_2 = 15
+		max_level = 2
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { government = monarchy }
+			}
+		}
+	}
+	custom_idea_horde_unity = {
+		horde_unity = 0.5
+		level_cost_2 = 15
+		max_level = 2
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { has_reform = steppe_horde }
+				NOT = { has_reform = great_mongol_state_reform }
+			}
+		}
+	}
+	custom_idea_devotion = {
+		devotion = 0.5
+		level_cost_2 = 15
+		max_level = 2
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { government = theocracy }
+			}
+		}	
+	}
+	custom_idea_republican_tradition = {
+		republican_tradition = 0.15
+		max_level = 2
+		level_cost_1 = 20
+		level_cost_2 = 60	
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { government = republic }
+			}
+			modifier = {
+				factor = 1.25
+				is_great_power = yes
+			}
+		}
+	}		
+	custom_idea_technology_cost = {
+		technology_cost = -0.05
+		level_cost_1 = 5
+		level_cost_2 = 30
+		max_level = 2
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+				adm = 3
+			}
+		}
+	}
+	custom_idea_idea_cost = {
+		idea_cost = -0.05
+		max_level = 2	
+		level_cost_1 = 3
+		level_cost_2 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				adm = 3
+			}
+		}
+	}		
+	custom_idea_advisor_cost = {
+		advisor_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+		}
+	}	
+	custom_idea_advisor_pool = {
+		advisor_pool = 1
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+	}	
+	custom_idea_tolerance_own = {
+		tolerance_own = 1
+		max_level = 2
+		level_cost_1 = 3
+		level_cost_2 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				dominant_religion = ROOT
+			}
+			modifier = {
+				factor = 1.25
+				government = theocracy
+			}
+		}
+	}
+	custom_idea_tolerance_heretic = {
+		tolerance_heretic = 1
+		max_level = 2
+		level_cost_1 = 3
+		level_cost_2 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				NOT = { dominant_religion = ROOT }
+			}
+			modifier = {
+				factor = 0
+				government = theocracy
+			}
+		}
+	}
+	custom_idea_tolerance_heathen = {
+		tolerance_heathen = 1
+		max_level = 2
+		level_cost_1 = 3
+		level_cost_2 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				NOT = { dominant_religion = ROOT }
+			}
+			modifier = {
+				factor = 0
+				government = theocracy
+			}
+		}
+	}
+	custom_idea_heir_chance = {
+		heir_chance = 0.25
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { government = monarchy }
+			}
+		}
+	}
+	custom_idea_enemy_core_creation = {
+		enemy_core_creation = 0.15
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_core_creation = {
+		core_creation = -0.05
+		chance = {
+			factor = 0.8
+			modifier = {
+				factor = 2
+				num_of_cities = 25
+			}
+			modifier = {
+				factor = 1.25
+				mil = 3
+			}
+		}
+	}
+	custom_idea_vassal_income = {
+		vassal_income = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { vassal = 1 }
+			}
+			modifier = {
+				factor = 3
+				vassal = 2
+			}
+		}
+	}
+	custom_idea_religious_unity = {
+		religious_unity = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				religious_unity = 0.95
+			}
+			modifier = {
+				factor = 1.1
+				NOT = { religious_unity = 0.75 }
+			}
+			modifier = {
+				factor = 1.25
+				NOT = { religious_unity = 0.50 }
+			}
+			modifier = {
+				factor = 1.25
+				NOT = { religious_unity = 0.25 }
+			}
+			modifier = {
+				factor = 1.15
+				religion = jainism
+			}
+			modifier = {
+				factor = 1.15
+				religion = buddhism
+			}
+		}
+	}
+	custom_idea_global_autonomy = {
+		global_autonomy = -0.05		
+		level_cost_1 = 5
+		level_cost_2 = 30
+		max_level = 2
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+				adm = 3
+			}
+		}
+	}
+	custom_idea_imperial_authority = {
+		imperial_authority = 0.1
+		level_cost_1 = 5
+		level_cost_2 = 30
+		max_level = 2
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				is_part_of_hre = no
+			}
+			modifier = {
+				factor = 4
+				is_emperor = yes
+			}
+		}
+	}
+	custom_idea_free_adm_policy = {
+		free_adm_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 20
+				adm = 6
+			}
+		}
+	}
+	custom_idea_possible_adm_policy = {
+		possible_adm_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_dip_custom_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_dip_custom_ideas.txt
@@ -1,0 +1,879 @@
+dip_idea_modifiers = {
+	category = DIP
+
+	custom_idea_accepted_culture_threshold = {
+		num_accepted_cultures = 1
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.5
+				NOT = { 
+					dominant_culture = ROOT 
+				}
+			}
+			modifier = {
+				factor = 0.1
+				NOT = {
+					any_owned_province = {
+						NOT = {
+							culture = ROOT
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 0.9
+				dominant_culture = ROOT
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					dip = 3
+				}
+			}
+			modifier = {
+				factor = 0.3
+				NOT = {
+					num_of_cities = 15
+				}
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					num_of_cities = 15
+				}
+			}
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = {
+					NOT = { 
+						culture_group = ROOT
+					}
+				}
+				dip = 3
+			}
+			modifier = {
+				factor = 1.1
+				 any_subject_country = {
+					is_subject_of = ROOT
+					NOT = {
+						culture_group = ROOT
+					}
+				}
+			}
+			modifier = {
+				factor = 10
+				num_accepted_cultures = 3
+			}
+		}
+	}	
+	custom_idea_culture_conversion_cost = {
+		culture_conversion_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0.5
+				dominant_culture = ROOT
+				num_of_cities = 15
+			}
+			modifier = {
+				factor = 0.1
+				NOT = {
+					any_owned_province = {
+						NOT = {
+							culture = ROOT
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					mil = 3
+				}
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					num_of_cities = 15
+				}
+			}
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = {
+					NOT = { 
+						culture_group = ROOT
+					}
+					any_owned_province = { 
+						is_claim = ROOT 
+					}
+				}
+				mil = 3
+			}
+			modifier = {
+				factor = 0.9
+				num_accepted_cultures = 1
+			}
+		}
+	}
+	custom_idea_naval_morale = {
+		naval_morale = 0.05
+		default = 4
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 1.5
+				OR = {
+					num_of_ports = 10
+					AND = {
+						NOT = { num_of_cities = 5 }
+						num_of_ports = 1
+					}
+					AND = {
+						NOT = { num_of_cities = 11 }
+						num_of_ports = 5
+					}
+				}
+			}
+		}
+	}
+	custom_idea_trade_efficiency = {
+		trade_efficiency = 0.05
+		default = 7
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				any_owned_province = {
+					province_has_center_of_trade_of_level = 1
+				}
+			}
+			modifier = {
+				factor = 1.5
+				num_of_ports = 10
+			}
+			modifier = {
+				factor = 1.1
+				OR = {
+					has_reform = merchants_reform
+					has_reform = venice_merchants_reform
+					has_reform = free_city
+					has_reform = trading_city
+					has_reform = veche_republic
+					has_reform = dutch_republic
+					has_reform = plutocratic_reform
+				}
+			}
+		}
+	}
+	custom_idea_global_trade_power = {
+		global_trade_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18			
+		default = 9
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				any_owned_province = {
+					province_has_center_of_trade_of_level = 1
+				}
+			}
+			modifier = {
+				factor = 1.25
+				OR = {
+					has_reform = merchants_reform
+					has_reform = venice_merchants_reform
+					has_reform = free_city
+					has_reform = trading_city
+					has_reform = veche_republic
+					has_reform = dutch_republic
+					has_reform = plutocratic_reform
+				}
+			}
+			modifier = {
+				factor = 1.25
+				num_of_ports = 10
+			}
+		}
+	}		
+	custom_idea_global_prov_trade_power_modifier = {
+		global_prov_trade_power_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 1.25
+				any_owned_province = {
+					OR = {
+						has_province_modifier = center_of_trade_modifier
+						has_province_modifier = inland_center_of_trade_modifier
+					}
+				}
+			}
+			modifier = {
+				factor = 1.1
+				num_of_ports = 10
+			}
+		}
+	}	
+	custom_idea_trade_steering = {
+		trade_steering = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 1.25
+				any_owned_province = {
+					province_has_center_of_trade_of_level = 1
+					has_port = yes
+				}
+			}
+			modifier = {
+				factor = 1.1
+				num_of_ports = 10
+			}
+		}
+	}
+	custom_idea_global_tariffs = {
+		global_tariffs = 0.05
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_diplomatic_reputation = {
+		diplomatic_reputation = 1
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 5
+				dip = 3
+			}
+		}
+	}	
+	custom_idea_diplomatic_upkeep = {
+		diplomatic_upkeep = 1
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				num_of_subjects = 1
+				dip = 3
+			}
+		}
+	}	
+	custom_idea_merchants = {
+		merchants = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 1.5
+				any_owned_province = {
+					province_has_center_of_trade_of_level = 1
+				}
+			}
+		}
+	}
+	custom_idea_colonists = {
+		colonists = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		
+		# Used for random generation
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+			}
+			modifier = {
+				factor = 3
+				any_empty_neighbor_province = {
+					 native_size = 1
+				}
+			}
+			modifier = {
+				factor = 4
+				num_of_ports = 5
+				capital_scope = {
+					OR = {
+						region = iberia_region
+						region = british_isles_region
+					}
+				}
+			}
+			modifier = {
+				factor = 1.1
+				technology_group = western
+			}
+		}
+	}
+	custom_idea_diplomats = {
+		diplomats = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 5
+				is_emperor = yes
+			}
+		}
+	}
+	custom_idea_naval_maintenance_modifier = {
+		naval_maintenance_modifier = -0.05
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+		}		
+	}	
+	custom_idea_naval_forcelimit_modifier = {
+		naval_forcelimit_modifier = 0.075
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+		}			
+	}	
+	custom_idea_ship_durability = {
+		ship_durability = 0.05
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 2
+				num_of_ports = 15
+			}
+		}			
+	}	
+	custom_idea_war_exhaustion = {
+		war_exhaustion = -0.05
+		level_cost_1 = 5
+		level_cost_2 = 30
+		max_level = 2
+		chance = {
+			factor = 0.5
+		}
+	}		
+	custom_idea_war_exhaustion_cost = {
+		war_exhaustion_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}		
+	}	
+	custom_idea_navy_tradition = {
+		navy_tradition = 0.5
+		level_cost_2 = 15
+		max_level = 2
+		
+		# Used for random generation
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}
+	}	
+	custom_idea_navy_tradition_decay = {
+		navy_tradition_decay = -0.005
+		level_cost_2 = 15
+		max_level = 2
+		
+		# Used for random generation
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}
+	}	
+	custom_idea_leader_naval_fire = {
+		leader_naval_fire = 1
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 50
+
+		# Used for random generation
+		chance = {
+			factor = 0.9
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}			
+	}	
+	custom_idea_leader_naval_shock = {
+		leader_naval_shock = 1
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 50
+		
+		# Used for random generation
+		chance = {
+			factor = 0.9
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}	
+	}
+	custom_idea_leader_naval_maneuver = {
+		leader_naval_manuever = 1
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 50
+		
+		# Used for random generation
+		chance = {
+			factor = 0.9
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}			
+	}		
+	custom_idea_spy_offence = {
+		spy_offence = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}		
+	custom_idea_spy_defense = {
+		global_spy_defence = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}	
+	custom_idea_ship_recruit_speed = {
+		global_ship_recruit_speed = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 0
+		}
+	}	
+	custom_idea_blockade_efficiency = {
+		blockade_efficiency = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 0
+		}			
+	}
+	custom_idea_embargo_efficiency = {
+		embargo_efficiency = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}	
+	custom_idea_prestige_from_naval = {
+		prestige_from_naval = 0.25
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+
+		# Used for random generation
+		chance = {
+			factor = 0
+		}
+	}	
+	custom_idea_range = {
+		range = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+		}			
+	}	
+	custom_idea_global_colonial_growth = {
+		global_colonial_growth = 5
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 10 }
+			}
+			modifier = {
+				factor = 1.25
+				any_empty_neighbor_province = {
+					 native_size = 1
+				}
+			}
+		}	
+	}	
+	custom_idea_ae_impact = {
+		ae_impact = -0.05
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 2.25
+				dip = 4
+			}
+		}
+	}	
+	custom_idea_privateer_efficiency = {
+		privateer_efficiency = 0.075
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 3 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 10 }
+			}
+			modifier = {
+				factor = 5
+				has_reform = pirate_republic_reform
+			}
+		}
+	}
+	custom_idea_diplomatic_annexation_cost = {
+		diplomatic_annexation_cost = -0.05
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_subjects = 1 }
+			}
+			modifier = {
+				factor = 1.25
+				num_of_subjects = 2
+			}
+			modifier = {
+				factor = 1.25
+				num_of_subjects = 3
+			}
+		}
+	}
+	custom_idea_heavy_ship_cost = {
+		heavy_ship_cost = -0.05
+		
+		# Used for random generation
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 2.0
+				capital_scope = {
+					is_island = yes
+				}
+			}
+			modifier = {
+				factor = 1.1
+				num_of_ports = 15
+			}
+			modifier = {
+				factor = 1.1
+				naval_supplies = 6
+			}
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+			}
+		}
+	}
+	custom_idea_light_ship_cost = {
+		light_ship_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 0.75
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 2.0
+				capital_scope = {
+					is_island = yes
+				}
+			}
+			modifier = {
+				factor = 1.1
+				naval_supplies = 3
+			}
+		}
+	}
+	custom_idea_galley_cost = {
+		galley_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 0.25
+				num_of_ports = 15
+			}
+			modifier = {
+				factor = 2.0
+				capital_scope = {
+					is_island = yes
+					continent = europe
+				}
+			}
+		}
+	}
+	custom_idea_transport_cost = {
+		transport_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 0
+		}			
+	}
+	custom_idea_heavy_ship_power = {
+		heavy_ship_power = 0.05
+		
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 1.2
+				technology_group = western
+				is_great_power = yes
+			}
+		}	
+	}	
+	custom_idea_light_ship_power = {
+		light_ship_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18		
+
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 1.3
+				OR = {
+					has_reform = merchants_reform
+					has_reform = venice_merchants_reform
+					has_reform = free_city
+					has_reform = trading_city
+					has_reform = veche_republic
+					has_reform = dutch_republic
+					has_reform = plutocratic_reform
+				}
+			}
+			modifier = {
+				factor = 1.1
+				technology_group = indian
+			}
+			modifier = {
+				factor = 1.1
+				technology_group = east_african
+			}
+			
+		}
+	}
+	custom_idea_galley_power = {
+		galley_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18	
+
+		# Used for random generation
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_cities = 5
+				NOT = { num_of_ports = 5 }
+			}
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 5 }
+				NOT = { num_of_ports = 1 }
+			}
+		}
+	}
+	
+	custom_idea_free_dip_policy = {
+		free_dip_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 20
+				dip = 6
+			}
+		}
+	}
+	custom_idea_possible_dip_policy = {
+		possible_dip_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_mil_custom_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/00_mil_custom_ideas.txt
@@ -1,0 +1,498 @@
+mil_idea_modifiers = {
+	category = MIL	
+	
+	custom_idea_land_morale = {
+		land_morale = 0.05
+		default = 1
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = { 
+					any_owned_province = { 
+						is_claim = ROOT 
+					} 
+				}
+			}
+			modifier = {
+				factor = 1.2
+				is_great_power = yes
+			}
+			modifier = {
+				factor = 1.1
+				uses_fervor = yes
+			}
+		}
+	}
+	custom_idea_discipline = {
+		discipline = 0.025
+		default = 6
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				any_neighbor_country = { 
+					any_owned_province = { 
+						is_claim = ROOT 
+					} 
+				}
+			}
+			modifier = {
+				factor = 1.3
+				is_great_power = yes
+			}
+			modifier = {
+				factor = 2
+				OR = {
+					has_reform = prussian_monarchy
+					has_reform = prussian_republic_reform
+					has_reform = ottoman_government
+					has_reform = rajput_kingdom
+				}
+			}
+		}
+	}
+	custom_idea_land_maintenance_modifier = {
+		land_maintenance_modifier = -0.05
+		default = 10
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 4
+				OR = {
+					has_reform = tsardom
+					has_reform = principality
+				}
+			}
+		}
+	}
+	custom_idea_merc_maintenance_modifier = {
+		merc_maintenance_modifier = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				government = republic
+			}
+			modifier = {
+				factor = 2
+				NOT = { num_of_cities = 3 }
+			}
+			modifier = {
+				factor = 5
+				has_reform = united_cantons_reform
+			}
+		}
+	}
+	custom_idea_mercenary_manpower = {
+		mercenary_manpower = 0.125
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 1.1
+				government = republic
+			}
+			modifier = {
+				factor = 5
+				has_reform = united_cantons_reform
+			}
+		}
+	}
+	custom_idea_land_forcelimit_modifier = {
+		land_forcelimit_modifier = 0.075
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				grain = 3
+			}
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+			}
+		}
+	}
+	custom_idea_global_manpower_modifier = {
+		global_manpower_modifier = 0.075
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				technology_group = eastern
+			}
+			modifier = {
+				factor = 1.1
+				is_great_power = yes
+			}
+		}
+	}
+	custom_idea_manpower_recovery_speed = {
+		manpower_recovery_speed = 0.05
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				OR = {
+					technology_group = indian
+					technology_group = muslim
+					technology_group = eastern
+					technology_group = ottoman
+				}
+			}
+		}
+	}
+	custom_idea_reinforce_speed = {
+		reinforce_speed = 0.075
+		chance = {
+			factor = 0.5
+		}
+	}
+	custom_idea_hostile_attrition = {
+		hostile_attrition = 0.5
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				NOT = { num_of_cities = 6 }
+				NOT = { total_development = 30 }
+			}
+			modifier = {
+				factor = 1.1
+				religion_group = pagan
+			}
+		}
+	}
+	custom_idea_army_tradition = {
+		army_tradition = 0.5
+		level_cost_2 = 15
+		max_level = 2
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_army_tradition_decay = {
+		army_tradition_decay = -0.005
+		level_cost_2 = 15
+		max_level = 2
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_leader_land_fire = {
+		leader_land_fire = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		chance = {
+			factor = 0.4
+			modifier = {
+				factor = 2
+				mil = 3
+			}
+		}
+	}
+	custom_idea_leader_land_shock = {
+		leader_land_shock = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		chance = {
+			factor = 0.4
+			modifier = {
+				factor = 2
+				mil = 3
+			}
+		}
+	}
+	custom_idea_leader_land_manuever = {
+		leader_land_manuever = 1
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 50
+		chance = {
+			factor = 0.4
+			modifier = {
+				factor = 2
+				mil = 3
+			}
+		}
+	}	
+	custom_idea_leader_siege = {
+		leader_siege = 1
+		max_level = 2
+		level_cost_1 = 30
+		level_cost_2 = 140
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 2
+				mil = 3
+			}
+		}
+	}	
+	custom_idea_regiment_recruit_speed = {
+		global_regiment_recruit_speed = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_prestige_from_land = {
+		prestige_from_land = 0.25
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_idea_defensiveness = {
+		defensiveness = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				OR = {
+					religion = baltic_pagan
+					religion = baltic_pagan_reformed
+				}
+			}
+		}
+	}
+	custom_idea_siege_ability = {
+		siege_ability = 0.05
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 2
+				technology_group = ottoman
+			}
+		}
+	}
+	custom_idea_vassal_forcelimit_bonus = {
+		vassal_forcelimit_bonus = 0.5		
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_subjects = 1 }
+			}
+			modifier = {
+				factor = 0.9
+				NOT = {
+					NOT = { num_of_subjects = 2 }
+				}
+			}
+		}
+	}	
+	custom_idea_infantry_power = {
+		infantry_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				technology_group = western
+				technology_group = sub_saharan
+				technology_group = high_american
+			}
+			modifier = {
+				factor = 1.25
+				government = tribal
+				NOT = { has_reform = steppe_horde }
+				NOT = { has_reform = great_mongol_state_reform }
+			}
+		}
+	}
+	custom_idea_cavalry_power = {
+		cavalry_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 5
+				OR = {
+					has_reform = steppe_horde
+					has_reform = great_mongol_state_reform
+					has_reform = cossacks_reform
+				}
+			}
+			modifier = {
+				factor = 1.1
+				OR = {
+					technology_group = muslim
+					technology_group = eastern
+					technology_group = sub_saharan
+				}
+			}
+			modifier = {
+				factor = 1.1
+				primary_culture = polish
+			}
+			modifier = {
+				factor = 1.25
+				calc_true_if = {
+					any_owned_province = {
+						has_terrain = steppe 
+					}
+					amount = 4
+				}
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					technology_group = andean
+					technology_group = south_american
+					technology_group = mesoamerican
+					technology_group = north_american
+				}
+			}
+		}
+	}
+	custom_idea_artillery_power = {
+		artillery_power = 0.05
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				OR = {
+					technology_group = chinese
+					technology_group = ottoman
+				}
+			}
+		}
+	}
+	custom_idea_infantry_cost = {
+		infantry_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				OR = {
+					technology_group = eastern
+					technology_group = indian
+					technology_group = chinese
+				}
+			}
+		}
+	}
+	custom_idea_cavalry_cost = {
+		cavalry_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				OR = {
+					technology_group = muslim
+					technology_group = eastern
+					technology_group = indian
+					technology_group = sub_saharan
+				}
+			}
+			modifier = {
+				factor = 2
+				OR = {
+					has_reform = steppe_horde
+					has_reform = great_mongol_state_reform
+					has_reform = cossacks_reform
+				}
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					technology_group = andean
+					technology_group = south_american
+					technology_group = mesoamerican
+					technology_group = north_american
+				}
+			}
+		}
+	}
+	custom_idea_artillery_cost = {
+		artillery_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				OR = {
+					technology_group = chinese
+					technology_group = ottoman
+				}
+			}
+		}
+	}
+	custom_idea_fort_maintenance = {
+		fort_maintenance_modifier = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.75
+			modifier = {
+				factor = 1.5
+				NOT = {
+					num_of_cities = 10
+				}
+				capital_scope = {
+					OR = {
+						has_terrain = mountain
+						has_terrain = highlands
+						has_terrain = hills
+					}
+				}
+			}
+		}
+	}
+	custom_idea_free_mil_policy = {
+		free_mil_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 20
+				mil = 6
+			}
+		}
+	}
+	custom_idea_possible_mil_policy = {
+		possible_mil_policy = 1
+		max_level = 1
+		level_cost_1 = 30
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 5
+				OR = {
+					has_reform = prussian_monarchy
+					has_reform = prussian_republic_reform
+				}
+				mil = 5
+			}
+		}
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/01_new_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/01_new_ideas.txt
@@ -1,0 +1,115 @@
+# cost = CFixedPoint( base_cost + ( level * level * level_cost ) ).GetTruncated()
+# DEFAULT: base_cost = 0, level_cost = 0.4, max_level = 4
+
+new_idea_adm_modifiers = {
+	category = ADM	
+	custom_idea_years_of_nationalism = {
+		years_of_nationalism = -5
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				is_great_power = yes
+				mil = 4
+			}
+		}
+	}
+	custom_idea_female_advisor_chance = {
+		female_advisor_chance = 0.1
+		max_level = 10
+		level_cost_1 = 0
+		level_cost_2 = 0
+		level_cost_3 = 0
+		level_cost_4 = 0
+		level_cost_5 = 0
+		level_cost_6 = 0
+		level_cost_7 = 0
+		level_cost_8 = 0
+		level_cost_9 = 0
+		level_cost_10 = 0
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+new_idea_mil_modifiers = {
+	category = MIL	
+	custom_idea_female_generals = {
+		may_recruit_female_generals = yes
+		max_level = 1
+		level_cost_1 = 5
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 0
+				is_female = no
+			}
+		}
+	}
+}
+
+
+new_idea_dip_modifiers = {
+	category = DIP	
+	
+	custom_idea_global_sailors_modifier = {
+		global_sailors_modifier = 0.1
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 3 }
+			}
+		}
+	}
+	custom_idea_sailors_recovery_speed = {
+		sailors_recovery_speed = 0.05
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 3 }
+			}
+		}
+	}
+	custom_idea_slave_raiders = {
+		may_perform_slave_raid = yes
+		max_level = 1
+		level_cost_1 = 20
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 1 }
+			}
+			modifier = {
+				factor = 0
+				religion_group = christian
+				NOT = { has_reform = monastic_order_reform }
+			}
+			modifier = {
+				factor = 5
+				religion = norse_pagan_reformed
+			}
+			modifier = {
+				factor = 10
+				NOT = { num_of_cities = 2 }
+				capital_scope = {
+					is_island = yes
+				}
+			}
+			modifier = {
+				factor = 10
+				capital_scope = {
+					region = maghreb_region
+				}
+			}
+		}
+	}
+}
+
+	

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/02_newer_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/02_newer_ideas.txt
@@ -1,0 +1,886 @@
+# cost = CFixedPoint( base_cost + ( level * level * level_cost ) ).GetTruncated()
+# DEFAULT: base_cost = 0, level_cost = 0.4, max_level = 4
+
+newer_idea_adm_modifiers = {
+	category = ADM	
+	custom_yearly_harmony = {
+		yearly_harmony = 0.25
+		max_level = 2
+		level_cost_2 = 5
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { religion = confucianism }
+			}
+		}
+	}
+	custom_harmonization_speed = {
+		harmonization_speed = 0.1
+		max_level = 2
+		level_cost_2 = 10
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { religion = confucianism }
+			}
+		}
+	}
+	custom_meritocracy = {
+		meritocracy = 0.5
+		max_level = 2
+		level_cost_2 = 15
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				is_emperor_of_china = no
+			}
+		}
+	}
+	custom_monarch_admin_power = {
+		monarch_admin_power = 1
+		max_level = 1
+		level_cost_1 = 60
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 10
+				adm = 6
+			}
+		}
+	}
+	custom_max_absolutism = {
+		max_absolutism = 5
+		level_cost_2 = 5
+		level_cost_3 = 15
+		level_cost_4 = 30
+		chance = {
+			factor = 0.2
+			modifier = {
+				factor = 0
+				government = republic
+				NOT = { has_reform = prussian_republic_reform }
+				NOT = { has_reform = cossacks_reform }
+			}
+			modifier = {
+				factor = 5
+				is_great_power = yes
+				OR = {
+					has_reform = ottoman_government
+					has_reform = autocracy_reform
+				}
+			}
+			modifier = {
+				factor = 1.5
+				is_great_power = yes
+			}
+		}
+	}
+	custom_yearly_absolutism = {
+		yearly_absolutism = 0.5
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 60
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				is_great_power = yes
+			}
+		}
+	}
+	custom_administrative_efficiency = {
+		administrative_efficiency = 0.05
+		max_level = 2
+		level_cost_1 = 15
+		level_cost_2 = 60
+		chance = {
+			factor = 0.25
+		}
+	}
+	custom_institution_spread_from_true_faith = {
+		institution_spread_from_true_faith = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 0
+				OR = {
+					has_reform = indian_sultanate_reform
+					NOT = { religious_unity = 0.6 }
+				}
+			}
+		}
+	}
+	custom_global_institution_spread = {
+		global_institution_spread = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.33
+		}
+	}
+	custom_embracement_cost = {
+		embracement_cost = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_governing_capacity_modifier = {
+		governing_capacity_modifier = 0.1
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.3
+				OR = {
+					num_of_cities = 30
+					AND = {
+						num_of_cities = 20
+						has_reform = merchants_reform
+					}
+				}
+			}
+		}
+	}
+	custom_church_power_modifier = {
+		church_power_modifier = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 0
+				uses_church_power = no
+			}
+		}
+	}
+	custom_yearly_corruption = {
+		yearly_corruption = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+		}
+	}
+	custom_caravan_power = {
+		caravan_power = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_ports = 10
+			}
+			modifier = {
+				factor = 2
+				any_owned_province = {
+					province_has_center_of_trade_of_level = 1
+				}
+			}
+		}
+	}
+	custom_monthly_fervor_increase = {
+		monthly_fervor_increase = 1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				uses_fervor = no
+			}
+		}
+	}
+	custom_global_trade_goods_size_modifier = {
+		global_trade_goods_size_modifier = 0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.5
+				government = republic
+			}
+		}
+	}
+	custom_adm_tech_cost_modifier = {
+		adm_tech_cost_modifier = -0.05
+		max_level = 2
+		level_cost_2 = 20
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 2
+				adm = 5
+			}
+		}
+	}
+	custom_build_time = {
+		build_time = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_state_maintenance_modifier = {
+		state_maintenance_modifier = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_autonomy_change_time = {
+		autonomy_change_time = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+newer_idea_mil_modifiers = {
+	category = MIL	
+	custom_merc_discipline = {
+		mercenary_discipline = 0.025
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 10
+				has_reform = united_cantons_reform
+			}
+		}
+	}
+	custom_rival_border_fort_maintenance = {
+		rival_border_fort_maintenance = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_siege_blockade_progress = {
+		siege_blockade_progress = 1
+		max_level = 1
+		level_cost_1 = 5
+		chance = {
+			factor = 0
+		}
+	}
+	custom_cav_to_inf_ratio = {
+		cav_to_inf_ratio = 0.15
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { religion_group = pagan }
+			}
+			modifier = {
+				factor = 0
+				NOT = { has_reform = steppe_horde }
+				NOT = { has_reform = great_mongol_state_reform }
+				NOT = { has_reform = cossacks_reform }
+			}
+		}
+	}
+	custom_artillery_bonus_vs_fort = {
+		artillery_bonus_vs_fort = 1
+		max_level = 2
+		level_cost_1 = 3
+		level_cost_2 = 10
+		chance = {
+			factor = 0
+		}
+	}
+	custom_monarch_military_power = {
+		monarch_military_power = 1
+		max_level = 1
+		level_cost_1 = 60
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 10
+				mil = 6
+			}
+		}
+	}
+	custom_backrow_artillery_damage = {
+		backrow_artillery_damage = 0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 4
+				OR = {
+					has_reform = mughal_government
+					culture_group = french
+					culture = byelorussian
+				}
+			}
+		}
+	}
+	custom_harsh_treatment_cost = {
+		harsh_treatment_cost = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_fire_damage_received = {
+		fire_damage_received = -0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				is_great_power = yes
+				mil = 3
+			}
+		}
+	}
+	custom_shock_damage_received = {
+		shock_damage_received = -0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				mil = 3
+			}
+		}
+	}
+	custom_cavalry_flanking = {
+		cavalry_flanking = 0.25
+		max_level = 2
+		level_cost_2 = 10
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { religion_group = pagan }
+			}
+			modifier = {
+				factor = 0
+				NOT = { has_reform = steppe_horde }
+				NOT = { has_reform = great_mongol_state_reform }
+				NOT = { has_reform = cossacks_reform }
+			}
+		}
+	}
+	custom_shock_damage = {
+		shock_damage = 0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.25
+				mil = 3
+			}
+			modifier = {
+				factor = 2
+				government = tribal
+			}
+			modifier = {
+				factor = 1.25
+				OR = {
+					has_reform = steppe_horde
+					has_reform = great_mongol_state_reform
+					has_reform = cossacks_reform
+				}
+			}
+		}
+	}
+	custom_fire_damage = {
+		fire_damage = 0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1.1
+		}
+	}
+	custom_movement_speed = {
+		movement_speed = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.9
+		}
+	}
+	custom_army_tradition_from_battle = {
+		army_tradition_from_battle = 0.5
+		max_level = 2
+		level_cost_2 = 5
+		chance = {
+			factor = 0
+		}
+	}
+	custom_monthly_militarized_society = {
+		monthly_militarized_society = 0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { has_reform = prussian_monarchy }
+				NOT = { has_reform = prussian_republic_reform }
+			}
+		}
+	}
+	custom_reinforce_cost_modifier = {
+		reinforce_cost_modifier = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_loot_amount = {
+		loot_amount = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_garrison_size = {
+		garrison_size = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_land_attrition = {
+		land_attrition = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_mil_tech_cost_modifier = {
+		mil_tech_cost_modifier = -0.05
+		max_level = 2
+		level_cost_2 = 20
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 2
+				mil = 5
+			}
+		}
+	}
+	custom_free_leader_pool = {
+		free_leader_pool = 1
+		max_level = 2
+		level_cost_2 = 10
+		chance = {
+			factor = 0
+		}
+	}
+	custom_global_regiment_cost = {
+		global_regiment_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_mercenary_cost = {
+		mercenary_cost = -0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 4
+				has_reform = united_cantons_reform
+			}
+		}
+	}
+	custom_recover_army_morale_speed = {
+		recover_army_morale_speed = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+
+newer_idea_dip_modifiers = {
+	category = DIP	
+	custom_warscore_cost_vs_other_religion = {
+		warscore_cost_vs_other_religion = -0.125
+		max_level = 2
+		level_cost_1 = 5
+		level_cost_2 = 15
+		chance = {
+			factor = 0
+		}
+	}
+	custom_war_taxes_cost_modifier = {
+		war_taxes_cost_modifier = -0.5
+		max_level = 2
+		level_cost_1 = 10
+		level_cost_2 = 20
+		chance = {
+			factor = 0
+		}
+	}
+	custom_monarch_diplomatic_power = {
+		monarch_diplomatic_power = 1
+		max_level = 1
+		level_cost_1 = 60
+		chance = {
+			factor = 0.1
+			modifier = {
+				factor = 10
+				dip = 6
+			}
+		}
+	}
+	custom_liberty_desire_from_subject_development = {
+		liberty_desire_from_subject_development = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 0
+				NOT = { num_of_subjects = 1 }
+			}
+		}
+	}
+	custom_reduced_liberty_desire_on_same_continent = {
+		reduced_liberty_desire_on_same_continent = 10
+		max_level = 2
+		level_cost_2 = 10
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 0
+				NOT = { num_of_subjects = 1 }
+			}
+		}
+	}
+	custom_naval_tradition_from_battle = {
+		naval_tradition_from_battle = 0.5
+		max_level = 2
+		level_cost_2 = 5
+		chance = {
+			factor = 0
+		}
+	}
+	custom_capture_ship_chance = {
+		capture_ship_chance = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_sunk_ship_morale_hit_recieved = {
+		sunk_ship_morale_hit_recieved = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 7 }
+			}
+		}
+	}
+	custom_global_naval_engagement_modifier = {
+		global_naval_engagement_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 10 }
+			}
+		}
+	}
+	custom_global_ship_trade_power = {
+		global_ship_trade_power = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 10 }
+			}
+		}
+	}
+	custom_native_assimilation = {
+		native_assimilation = 0.15
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_native_uprising_chance = {
+		native_uprising_chance = -0.25
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_reduced_liberty_desire = {
+		reduced_liberty_desire = 5
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.33
+			modifier = {
+				factor = 0
+				NOT = { num_of_subjects = 1 }
+			}
+		}
+	}
+	custom_migration_cooldown = {
+		migration_cooldown = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 0
+				NOT = { num_of_cities = 2 }
+				has_reform = siberian_tribe
+			}
+		}
+	}
+	custom_envoy_travel_time = {
+		envoy_travel_time = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_province_warscore_cost = {
+		province_warscore_cost = -0.1
+		max_level = 2
+		level_cost_2 = 20
+		chance = {
+			factor = 0
+		}
+	}
+	custom_dip_tech_cost_modifier = {
+		dip_tech_cost_modifier = -0.05
+		max_level = 2
+		level_cost_2 = 20
+		chance = {
+			factor = 0.5
+			modifier = {
+				factor = 2
+				dip = 5
+			}
+		}
+	}
+	custom_papal_influence = {
+		papal_influence = 1
+		max_level = 2
+		level_cost_2 = 20
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { religion = catholic }
+			}
+			modifier = {
+				factor = 1.25
+				government = theocracy
+			}
+		}
+	}
+	custom_trade_range_modifier = {
+		trade_range_modifier = 0.2
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_auto_explore_adjacent_to_colony = {
+		auto_explore_adjacent_to_colony = yes
+		max_level = 1
+		chance = {
+			factor = 0
+		}
+	}
+	custom_unjustified_demands = {
+		unjustified_demands = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_rebel_support_efficiency = {
+		rebel_support_efficiency = 0.2
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_placed_merchant_power = {
+		placed_merchant_power = 5
+		max_level = 2
+		level_cost_2 = 10
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				OR = {
+					has_reform = plutocratic_reform
+					has_reform = merchants_reform
+				}
+			}
+		}
+	}
+	custom_global_own_trade_power = {
+		global_own_trade_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 1.1
+				dip = 4
+			}
+		}
+	}
+	custom_recover_navy_morale_speed = {
+		recover_navy_morale_speed = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_global_foreign_trade_power = {
+		global_foreign_trade_power = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_improve_relation_modifier = {
+		improve_relation_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0.33
+			modifier = {
+				factor = 0
+				is_emperor = no
+			}
+		}
+	}
+	custom_possible_condottieri = {
+		possible_condottieri = 0.25
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { has_reform = united_cantons_reform }
+			}
+			modifier = {
+				factor = 0
+				is_part_of_hre = no
+			}
+		}
+	}
+	custom_naval_attrition = {
+		naval_attrition = -0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+	

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/02_newer_newer_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/02_newer_newer_ideas.txt
@@ -1,0 +1,158 @@
+# cost = CFixedPoint( base_cost + ( level * level * level_cost ) ).GetTruncated()
+# DEFAULT: base_cost = 0, level_cost = 0.4, max_level = 4
+
+newer_newer_idea_adm_modifiers = {
+	category = ADM	
+	custom_negative_piety = {
+		monthly_piety = -0.001
+		max_level = 2
+		level_cost_1 = 9
+		level_cost_2 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_positive_piety = {
+		monthly_piety = 0.001
+		max_level = 2
+		level_cost_1 = 9
+		level_cost_2 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_reform_progress = {
+		reform_progress_growth = 0.075
+		max_level = 4
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_free_religion = {
+		no_religion_penalty = yes
+		max_level = 1
+		level_cost_1 = 60
+		chance = {
+			factor = 0
+		}
+	}
+	custom_same_culture_idea_advisor_cost = {
+		same_culture_advisor_cost = -0.05
+		level_cost_2 = 1
+		level_cost_3 = 6
+		level_cost_4 = 9
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { religion_group = jewish_group }
+				NOT = { religion = yazidi }
+			}
+		}
+	}		
+}
+
+
+newer_newer_idea_dip_modifiers = {
+	category = DIP	
+	custom_power_prod_insults = {
+		power_projection_from_insults = 1
+		max_level = 1
+		level_cost_1 = 25
+		chance = {
+			factor = 0
+		}
+	}
+	custom_manifest_destiny = {
+		cb_on_primitives = yes
+		max_level = 1
+		level_cost_1 = 50
+		chance = {
+			factor = 0
+		}
+	}
+	custom_justify_conflict_cost = {
+		justify_trade_conflict_cost = -0.175
+		max_level = 4
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_claim_fab_cost = {
+		fabricate_claims_cost = -0.175
+		max_level = 4
+		level_cost_2 = 9
+		level_cost_3 = 18
+		level_cost_4 = 30
+		chance = {
+			factor = 0
+		}
+	}
+	custom_sailor_maintenance = {
+		sailor_maintenance_modifer = -0.1
+		max_level = 4
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_coastal_combat = {
+		own_coast_naval_combat_bonus = 0.5
+		max_level = 4
+		level_cost_1 = 5
+		level_cost_2 = 10
+		level_cost_3 = 20
+		level_cost_3 = 40
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+newer_newer_idea_mil_modifiers = {
+	category = MIL	
+	custom_artillery_fire = {
+		artillery_fire = 1
+		max_level = 1
+		level_cost_1 = 25
+		chance = {
+			factor = 0.25
+			modifier = {
+				factor = 4
+				OR = {
+					has_reform = mughal_government
+					culture_group = french
+					culture = byelorussian
+				}
+			}
+		}
+	}
+	custom_manchu_ban = {
+		amount_of_banners = 0.125
+		max_level = 4
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	custom_garrison_growth = {
+		global_garrison_growth = 0.175
+		max_level = 4
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/03_tr_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/03_tr_ideas.txt
@@ -1,0 +1,19 @@
+tr_idea_dip_modifiers = {
+	category = DIP
+	custom_establish_frontier_ability = {
+		may_establish_frontier = yes
+		max_level = 1
+		level_cost_1 = 200
+		chance = {
+			factor = 4
+			modifier = {
+				factor = 0
+				NOT = { has_reform = tsardom }
+			}
+		}
+
+		enabled = {
+			has_dlc = "Third Rome"
+		}
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/04_emperor_ideas.txt
+++ b/CK2ToEU4/Data_Files/blankMod/output/common/custom_ideas/04_emperor_ideas.txt
@@ -1,0 +1,209 @@
+emperor_idea_adm_modifiers = {
+	category = ADM
+	
+	custom_max_zeal = {
+		max_revolutionary_zeal = 5
+		level_cost_2 = 5
+		level_cost_3 = 15
+		level_cost_4 = 30
+		chance = {
+			factor = 0
+		}
+		enabled = {
+			has_dlc = "Emperor"
+		}
+	}
+	
+	custom_monarch_lifespan = {
+		monarch_lifespan = 0.1
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { ruler_age = 80 }
+			}
+		}
+	}
+	
+	custom_patriarch_authority = {
+		yearly_patriarch_authority = 0.005
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				uses_patriarch_authority = no
+			}
+		}
+		enabled = {
+			has_dlc = "Third Rome"
+		}
+	}
+	
+	custom_church_loyalty = {
+		church_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_dhimmi_loyalty = {
+		dhimmi_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_jains_loyalty = {
+		jains_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}
+
+emperor_idea_dip_modifiers = {
+	category = DIP
+	
+	custom_burghers_loyalty = {
+		burghers_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_vaisyas_loyalty = {
+		vaisyas_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_allowed_marine_fraction = {
+		allowed_marine_fraction = 0.05
+		level_cost_2 = 5
+		max_level = 2
+		chance = {
+			factor = 1.5
+			modifier = {
+				factor = 0
+				NOT = { num_of_ports = 5 }
+			}
+		}
+	
+		enabled = {
+			OR = {
+				has_dlc = "Rule Britannia"
+				has_dlc = "Golden Century"
+			}
+		}
+	}
+	
+	custom_mercantilism_cost = {
+		mercantilism_cost = -0.05
+		level_cost_2 = 5
+		level_cost_3 = 15		
+		level_cost_4 = 30
+		chance = {
+			factor = 0
+		}
+
+		enabled = {
+			has_dlc = "Mare Nostrum"
+		}
+	}
+}
+
+emperor_idea_mil_modifiers = {
+	category = MIL
+	
+	custom_available_province_loot = {
+		available_province_loot = 0.15
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_special_unit_forcelimit = {
+		special_unit_forcelimit = 0.15
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18		
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_nobles_loyalty = {
+		nobles_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_maratha_loyalty = {
+		maratha_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_rajput_loyalty = {
+		rajput_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_cossacks_loyalty = {
+		cossacks_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+	
+	custom_nomadic_tribes_loyalty = {
+		nomadic_tribes_loyalty_modifier = 0.05
+		level_cost_2 = 3
+		level_cost_3 = 9
+		level_cost_4 = 18
+		chance = {
+			factor = 0
+		}
+	}
+}

--- a/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_english.yml
+++ b/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_english.yml
@@ -66,3 +66,9 @@
  wonder_underground_city_petra: "Petra"
  desc_wonder_underground_city_petra: "The great desert city of Petra has existed for hundreds of years"
  
+ #Custom Idea Forgotten by PDX, text taken from old state maintenance text
+ custom_governing_capacity_modifier:1 "Provincial Allowances"
+ custom_governing_capacity_modifier_desc:1 "By granting special privileges and allowances to our State Governors, we can cut back slightly on the expenses of their services."
+ 
+ 
+ 

--- a/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_french.yml
+++ b/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_french.yml
@@ -51,3 +51,8 @@
  hellenic_pagan_reformed_rebels_name: "Fanatiques $RELIGION$"
  hellenic_pagan_reformed_rebels_desc: "Les fanatiques religieux tendent à se soulever dans les provinces contrôlées par des pays d'une autre foi. Ils cherchent à répandre leur foi et s'en prennent aux infidèles."
  hellenic_pagan_reformed_rebels_army: "Armée $RELIGION$"
+ 
+ #Custom Idea Forgotten by PDX, text taken from old state maintenance text
+ custom_governing_capacity_modifier:1 "Allocations provinciales"
+ custom_governing_capacity_modifier_desc:1 "En accordant des privilèges et allocations particuliers aux gouverneurs des États, nous pouvons réduire les dépenses liées à leur fonctionnement."
+ 

--- a/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_german.yml
+++ b/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_german.yml
@@ -53,3 +53,8 @@
  hellenic_pagan_reformed_rebels_name: "$RELIGION$ Fanatiker"
  hellenic_pagan_reformed_rebels_desc: "Religiöse Fanatiker erheben sich vor allem in Provinzen, deren Religion von der Staatsreligion abweicht. Sie wollen ihre Religion verbreiten und alle Ungläubigen bekehren."
  hellenic_pagan_reformed_rebels_army: "$RELIGION$ Armee"
+
+ #Custom Idea Forgotten by PDX, text taken from old state maintenance text
+ custom_governing_capacity_modifier:1 "Provinzialzulagen"
+ custom_governing_capacity_modifier_desc:1 "Durch die Gewährung besonderer Privilegien und Zulagen an unsere Staatsgouverneure können wir die Kosten ihrer Dienstleistungen geringfügig reduzieren."
+ 

--- a/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_spanish.yml
+++ b/CK2ToEU4/Data_Files/blankMod/output/localisation/converted_misc_l_spanish.yml
@@ -53,3 +53,8 @@
  hellenic_pagan_reformed_rebels_name: "Fanáticos del $RELIGION$"
  hellenic_pagan_reformed_rebels_desc: "Los fanáticos religiosos suelen aparecer en provincias controladas por una nación con distintas creencias. Pretenden difundir su doctrina y castigar a los infieles."
  hellenic_pagan_reformed_rebels_army: "Ejército del $RELIGION$"
+
+ #Custom Idea Forgotten by PDX, text taken from old state maintenance text
+ custom_governing_capacity_modifier:1 "Sobresueldos provinciales"
+ custom_governing_capacity_modifier_desc:0 "Concediendo privilegios y sobresueldos especiales a nuestros gobernadores provinciales, podemos reducir ligeramente los gastos de sus servicios."
+ 

--- a/CK2ToEU4/Source/EU4World/Country/Country.cpp
+++ b/CK2ToEU4/Source/EU4World/Country/Country.cpp
@@ -506,7 +506,7 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		auto adjLocalizationMatch = localizationMapper.getLocBlockForKey(alternateAdj);
 		if (adjLocalizationMatch)
 		{
-			localizations.insert(std::pair(tag, *adjLocalizationMatch));
+			localizations.insert(std::pair(tag + "_ADJ", *adjLocalizationMatch));
 			adjSet = true;
 		}
 	}
@@ -518,12 +518,35 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		auto adjLocalizationMatch = localizationMapper.getLocBlockForKey(alternateAdj);
 		if (adjLocalizationMatch)
 		{
-			localizations.insert(std::pair(tag, *adjLocalizationMatch));
+			localizations.insert(std::pair(tag + "_ADJ", *adjLocalizationMatch));
 			adjSet = true;
 		}
 	}
 	if (!adjSet)
 		Log(LogLevel::Warning) << tag << " help with localization for adjective! " << title.first << "_adj?";
+
+	// Setting Up Idea Names
+	if (adjSet && !localizations.find(tag + "_ADJ")->second.english.empty())
+	{
+		mappers::LocBlock newblock;
+		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Ideas"; // Roman Ideas
+		newblock.spanish = "Ideas de " + localizations.find(tag + "_ADJ")->second.spanish;
+		newblock.french = "Doctrines " + localizations.find(tag + "_ADJ")->second.french;
+		newblock.german = localizations.find(tag + "_ADJ")->second.german + " Ideen";
+		localizations.insert(std::pair(tag + "_ideas", newblock));
+
+		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Traditions"; // Roman Traditions
+		newblock.spanish = "Tradiciones de " + localizations.find(tag + "_ADJ")->second.spanish;
+		newblock.french = "traditions " + localizations.find(tag + "_ADJ")->second.french;
+		newblock.german = localizations.find(tag + "_ADJ")->second.german + " Traditionen";
+		localizations.insert(std::pair(tag + "_ideas_start", newblock));
+
+		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Ambition"; // Roman Ambition
+		newblock.spanish = "Ambición de " + localizations.find(tag + "_ADJ")->second.spanish;
+		newblock.french = "ambitions " + localizations.find(tag + "_ADJ")->second.french;
+		newblock.german = localizations.find(tag + "_ADJ")->second.german + " Ambitionen";
+		localizations.insert(std::pair(tag + "_ideas_bonus", newblock));
+	}
 
 	// Rulers
 	initializeRulers(religionMapper, cultureMapper, rulerPersonalitiesMapper, startDateOption, theConversionDate);
@@ -1310,6 +1333,12 @@ void EU4::Country::assignReforms(const std::shared_ptr<mappers::RegionMapper>& r
 		details.government = "republic";
 		details.reforms.clear();
 		details.reforms = {"peasants_republic"};
+	}
+	// Swiss Cantons
+	else if (details.reforms.count("peasants_republic") && details.primaryCulture == "swiss")
+	{
+		details.reforms.clear();
+		details.reforms = {"united_cantons_reform"};
 	}
 	// Free City (HRE) - These have already been set in EU4World.cpp by the setFreeCities() method
 

--- a/CK2ToEU4/Source/EU4World/Country/Country.cpp
+++ b/CK2ToEU4/Source/EU4World/Country/Country.cpp
@@ -526,7 +526,7 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		Log(LogLevel::Warning) << tag << " help with localization for adjective! " << title.first << "_adj?";
 
 	// Setting Up Idea Names
-	if (adjSet && !localizations.find(tag + "_ADJ")->second.english.empty())
+	if (adjSet && !title.second->isThePope() && !localizations.find(tag + "_ADJ")->second.english.empty())
 	{
 		mappers::LocBlock newblock;
 		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Ideas"; // Roman Ideas

--- a/CK2ToEU4/Source/EU4World/Country/Country.cpp
+++ b/CK2ToEU4/Source/EU4World/Country/Country.cpp
@@ -526,7 +526,7 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		Log(LogLevel::Warning) << tag << " help with localization for adjective! " << title.first << "_adj?";
 
 	// Setting Up Idea Names
-	if (adjSet && !title.second->isThePope() && !localizations.find(tag + "_ADJ")->second.english.empty())
+	if (adjSet && localizations.count(tag + "_ADJ") && !localizations.find(tag + "_ADJ")->second.english.empty())
 	{
 		mappers::LocBlock newblock;
 		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Ideas"; // Roman Ideas
@@ -542,7 +542,7 @@ void EU4::Country::initializeFromTitle(std::string theTag,
 		localizations.insert(std::pair(tag + "_ideas_start", newblock));
 
 		newblock.english = localizations.find(tag + "_ADJ")->second.english + " Ambition"; // Roman Ambition
-		newblock.spanish = "Ambición de " + localizations.find(tag + "_ADJ")->second.spanish;
+		newblock.spanish = "AmbiciÃ³n de " + localizations.find(tag + "_ADJ")->second.spanish;
 		newblock.french = "ambitions " + localizations.find(tag + "_ADJ")->second.french;
 		newblock.german = localizations.find(tag + "_ADJ")->second.german + " Ambitionen";
 		localizations.insert(std::pair(tag + "_ideas_bonus", newblock));

--- a/CK2ToEU4/Source/EU4World/Output/outCountry.cpp
+++ b/CK2ToEU4/Source/EU4World/Output/outCountry.cpp
@@ -144,6 +144,9 @@ std::ostream& EU4::operator<<(std::ostream& output, const Country& country)
 
 void EU4::Country::outputCommons(std::ostream& output) const
 {
+	// Activates Dynamic Ideas, *ONLY APPLIES TO COUNTRIES THAT WOULD RECIEVE GENERIC NATIONAL IDEAS!*
+	output << "ck2_converter_generated = yes\n";
+
 	if (!details.graphicalCulture.empty())
 		output << "graphical_culture = " << details.graphicalCulture << "\n";
 	if (details.color)


### PR DESCRIPTION
- Dynamic ideas added for all nations that would normally get generic ideas. (These ideas LOAD ON GAME START! You cannot see them in the "choose nation screen.")
- Small fixes for adj setting methods.
- Names of ideas are now based on what the country's adjective was in CK3 rather than what it is in EU4.
- Small loc fix for vanilla EU4, there until PDX fixes it.