### PR TITLE
Fix Hole At Province 2831

### DIFF
--- a/CK2ToEU4/Data_Files/configurables/sunset/history/provinces/2831.txt
+++ b/CK2ToEU4/Data_Files/configurables/sunset/history/provinces/2831.txt
@@ -4,6 +4,7 @@ controller = INC
 
 add_core = INC
 add_core = PCJ
+add_core = CRA
 
 culture = aimara
 


### PR DESCRIPTION
- Adds core for Charca (CRA) to province 2831, to remove the hole it leaves in cores.