### PR TITLE
Jin converts to the right Jin

### DIFF
--- a/CK2ToEU4/Data_Files/configurables/chinese_tag_mappings.txt
+++ b/CK2ToEU4/Data_Files/configurables/chinese_tag_mappings.txt
@@ -5,7 +5,7 @@
 # mappings, it will default to fallback.
 
 link = { ck2 = tang_china eu4 = TNG }
-link = { ck2 = jin_china eu4 = JIN }
+link = { ck2 = jin_china eu4 = MCH } # 晉 is not the same as 金
 link = { ck2 = wei_china eu4 = WEI }
 link = { ck2 = qi_china eu4 = QIC }
 link = { ck2 = zhou_china eu4 = CZH }


### PR DESCRIPTION
Considering Jin (晉) and Shanxi are interchangeable in Chinese, we probably shouldn't touch EU4's tag for it. So that's why I suggested Manchu as the nation to convert to since Manchu in EU4 represents Later Jin (金)