### PR TITLE
Monument base fix

### DIFF
--- a/CK2ToEU4/Data_Files/configurables/culture_map.txt
+++ b/CK2ToEU4/Data_Files/configurables/culture_map.txt
@@ -7,10 +7,13 @@
 
 # North Germanic
 
+link = { eu4 = icelandic ck2 = norse ck2 = norwegian ck2 = danish ck2 = swedish tech = western gfx = westerngfx region = subarctic_islands_area }
+link = { eu4 = swedish ck2 = norse tech = western gfx = westerngfx region = norrland_area region = gotaland_area region = bothnia_area province = 4151 region = vastra_gotaland_area region = ostra_svealand_area }
 link = { eu4 = swedish ck2 = swedish tech = western gfx = westerngfx }
+link = { eu4 = norwegian ck2 = norse tech = western gfx = westerngfx region = northern_norway region = eastern_norway region = western_norway province = 315 }
 link = { eu4 = norwegian ck2 = norwegian tech = western gfx = westerngfx }
+link = { eu4 = danish ck2 = norse tech = western gfx = westerngfx region = jutland_area region = denmark_area region = north_german_region region = skaneland_area }
 link = { eu4 = danish ck2 = danish tech = western gfx = westerngfx }
-link = { eu4 = icelandic ck2 = norse ck2 = norwegian ck2 = danish ck2 = swedish province = 370 province = 371 tech = western gfx = westerngfx }
 link = { eu4 = hannoverian ck2 = old_saxon tech = western gfx = westerngfx }
 link = { eu4 = norse ck2 = norse tech = western gfx = westerngfx } #PLEASE KEEP THIS LINE HERE!
 

--- a/CK2ToEU4/Source/CK2World/Wonders/Wonder.cpp
+++ b/CK2ToEU4/Source/CK2World/Wonders/Wonder.cpp
@@ -15,7 +15,7 @@ void CK2::Wonder::registerKeys()
 {
 	registerKeyword("type", [this](const std::string& unused, std::istream& theStream) {
 		type = commonItems::singleString(theStream).getString();
-		upgrades.insert(type);
+		upgrades.emplace_back(type);
 	});
 	registerKeyword("province", [this](const std::string& unused, std::istream& theStream) {
 		provinceID = commonItems::singleInt(theStream).getInt();
@@ -36,7 +36,7 @@ void CK2::Wonder::registerKeys()
 			if (const auto& tempDate = historyItem.getBinaryDate(); binaryDate == 0 || tempDate < binaryDate) // Gets the earliest date
 				binaryDate = tempDate;
 			if (!historyItem.getUpgrade().empty())
-				upgrades.insert(historyItem.getUpgrade());
+				upgrades.emplace_back(historyItem.getUpgrade());
 		}
 	});
 	registerKeyword("stage", [this](const std::string& unused, std::istream& theStream) {
@@ -44,7 +44,7 @@ void CK2::Wonder::registerKeys()
 		if (stage < 0)
 		{
 			stage = 0;
-			upgrades.emplace("generic_misc_upgrade_3");
+			upgrades.emplace_back("generic_misc_upgrade_3");
 		}
 		else if (stage > 3) // For mods
 		{

--- a/CK2ToEU4/Source/CK2World/Wonders/Wonder.h
+++ b/CK2ToEU4/Source/CK2World/Wonders/Wonder.h
@@ -34,7 +34,7 @@ class Wonder: commonItems::parser
 	[[nodiscard]] const auto& getUpgrades() const { return upgrades; }
 	[[nodiscard]] auto isSpent() const { return spent; }
 
-	void addUpgrade(const std::string& mod) { upgrades.emplace(mod); }
+	void addUpgrade(const std::string& mod) { upgrades.emplace_back(mod); }
 	void setWonderID(int mod) { wonderID = mod; }
 	void setName(const std::string& newName) { name = newName; }
 	void setTrueDate(int binDate);
@@ -69,7 +69,7 @@ class Wonder: commonItems::parser
 	std::string builderReligion;
 	std::string buildTrigger;
 
-	std::set<std::string> upgrades;
+	std::vector<std::string> upgrades;
 	std::vector<std::string> onUpgraded;
 	std::map<std::string, std::vector<double>> provinceModifiers;
 	std::map<std::string, std::vector<double>> areaModifiers;

--- a/CK2ToEU4/Source/EU4World/Output/outMonument.cpp
+++ b/CK2ToEU4/Source/EU4World/Output/outMonument.cpp
@@ -8,8 +8,9 @@ EU4::outMonument::outMonument(const Configuration& theConfiguration, std::option
 		Log(LogLevel::Error) << "You fed me a dangling pointer.";
 		return;
 	}
-	if (wonder->second->getProvinceModifiers().empty() && wonder->second->getAreaModifiers().empty() &&
-		 wonder->second->getCountryModifiers().empty()) // This is a modded monument, probably better to not convert
+
+	if (!wonder->second->hasBase() || (wonder->second->getProvinceModifiers().empty() && wonder->second->getAreaModifiers().empty() &&
+													  wonder->second->getCountryModifiers().empty())) // This is a modded monument, probably better to not convert
 		return;
 
 	std::ofstream output("output/" + theConfiguration.getOutputName() + "/common/great_projects/!00_converted_monuments.txt", std::ios::out | std::ios::app);

--- a/CK2ToEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK2ToEU4/Source/EU4World/Province/EU4Province.cpp
@@ -26,7 +26,7 @@ void EU4::Province::initializeFromCK2(std::shared_ptr<CK2::Province> origProvinc
 	 const mappers::ReligionMapper& religionMapper)
 {
 	srcProvince = std::move(origProvince);
-	details.discoveredBy = {"eastern", "western", "muslim", "ottoman", "indian", "nomad_group"}; // hardcoding for now.
+	details.discoveredBy = {"eastern", "western", "muslim", "ottoman", "indian", "nomad_group", "MGE"}; // hardcoding for now.
 
 	// If we're initializing this from CK2 provinces, then having an owner or being a wasteland/sea is a given -
 	// there are no uncolonized provinces in CK2.

--- a/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.cpp
+++ b/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.cpp
@@ -13,7 +13,6 @@ mappers::InternalModifiers::InternalModifiers(std::istream& theStream)
 void mappers::InternalModifiers::registerKeys()
 {
 	registerRegex(commonItems::catchallRegex, [this](const std::string& mod, std::istream& theStream) {
-		modifierType = mod;
-		modifierValues = commonItems::doubleList(theStream).getDoubles();
+		modifierMap.emplace(mod, commonItems::doubleList(theStream).getDoubles());
 	});
 }

--- a/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.h
+++ b/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.h
@@ -15,7 +15,7 @@ class InternalModifiers: commonItems::parser
   private:
 	void registerKeys();
 
-	std::map<std::string, std::vector<double>> modifierMap; //e.g. local_defensiveness, {0.05, 0.2, 0.33, 0.33}
+	std::map<std::string, std::vector<double>> modifierMap; // e.g. local_defensiveness, {0.05, 0.2, 0.33, 0.33}
 };
 } // namespace mappers
 

--- a/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.h
+++ b/CK2ToEU4/Source/Mappers/MonumentsMapper/InternalModifiers.h
@@ -10,14 +10,12 @@ class InternalModifiers: commonItems::parser
 	InternalModifiers() = default;
 	explicit InternalModifiers(std::istream& theStream);
 
-	[[nodiscard]] const auto& getModifierType() const { return modifierType; }
-	[[nodiscard]] const auto& getModifierValues() const { return modifierValues; }
+	[[nodiscard]] const auto& getModifierMap() const { return modifierMap; }
 
   private:
 	void registerKeys();
 
-	std::string modifierType;				// e.g. local_defensiveness
-	std::vector<double> modifierValues; // e.g. {0.05, 0.2, 0.33, 0.33}
+	std::map<std::string, std::vector<double>> modifierMap; //e.g. local_defensiveness, {0.05, 0.2, 0.33, 0.33}
 };
 } // namespace mappers
 

--- a/CK2ToEU4/Source/Mappers/MonumentsMapper/MonumentsMapping.cpp
+++ b/CK2ToEU4/Source/Mappers/MonumentsMapper/MonumentsMapping.cpp
@@ -63,5 +63,5 @@ void mappers::MonumentsMapping::AddCountrySet(std::istream& theStream)
 	InternalModifiers mods(theStream);
 	for (auto tempMod: mods.getModifierMap())
 		if (!countryModifiers.contains(tempMod.first))
-			countryModifiers.emplace(tempMod.first, tempMod.second);	
+			countryModifiers.emplace(tempMod.first, tempMod.second);
 }

--- a/CK2ToEU4/Source/Mappers/MonumentsMapper/MonumentsMapping.cpp
+++ b/CK2ToEU4/Source/Mappers/MonumentsMapper/MonumentsMapping.cpp
@@ -47,27 +47,21 @@ void mappers::MonumentsMapping::registerKeys()
 void mappers::MonumentsMapping::AddProvinceSet(std::istream& theStream)
 {
 	InternalModifiers mods(theStream);
-	const auto& tempMod = mods.getModifierType();
-	const auto& tempValues = mods.getModifierValues();
-
-	if (!provinceModifiers.contains(tempMod))
-		provinceModifiers.emplace(tempMod, tempValues);
+	for (auto tempMod: mods.getModifierMap())
+		if (!provinceModifiers.contains(tempMod.first))
+			provinceModifiers.emplace(tempMod.first, tempMod.second);
 }
 void mappers::MonumentsMapping::AddAreaSet(std::istream& theStream)
 {
 	InternalModifiers mods(theStream);
-	const auto& tempMod = mods.getModifierType();
-	const auto& tempValues = mods.getModifierValues();
-
-	if (!areaModifiers.contains(tempMod))
-		areaModifiers.emplace(tempMod, tempValues);
+	for (auto tempMod: mods.getModifierMap())
+		if (!areaModifiers.contains(tempMod.first))
+			areaModifiers.emplace(tempMod.first, tempMod.second);
 }
 void mappers::MonumentsMapping::AddCountrySet(std::istream& theStream)
 {
 	InternalModifiers mods(theStream);
-	const auto& tempMod = mods.getModifierType();
-	const auto& tempValues = mods.getModifierValues();
-
-	if (!countryModifiers.contains(tempMod))
-		countryModifiers.emplace(tempMod, tempValues);
+	for (auto tempMod: mods.getModifierMap())
+		if (!countryModifiers.contains(tempMod.first))
+			countryModifiers.emplace(tempMod.first, tempMod.second);	
 }


### PR DESCRIPTION
- Norse culture-split added
- Upgrades now stored as groups (maps) instead of individual items. (This allows mappings that have multiple entries under one modifier-type to give all of those entries rather than just the last one listed)
- MGE given vision as it is Chinese Tech by default, blinding it to all of its western neighbors